### PR TITLE
Solution to unresponsive repl in Windows OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ Add the following to your Emacs config to enable
 
 `M-x inf-clojure` or `C-c C-z` within a Clojure source file.
 
+## Troubleshooting
+
+### REPL not responsive in Windows OS
+
+In Windows, the repl not returning anything. For example, `(+ 1 1)` and `ENTER`, the cursor just drops to new line and nothing shown.
+
+The explanation of this problem and solution can be found here https://groups.google.com/forum/#!topic/leiningen/48M-xvcI2Ng . 
+
+The solution is to create file named `.jline.rc` in your $HOME directory and write this line in that file.
+
+`jline.terminal=unsupported`
+
+
 ## License
 
 Copyright © 2014 Bozhidar Batsov and [contributors][].


### PR DESCRIPTION
in Windows OS, the repl is not responsive. for example, typing `(+ 1 1)` and `ENTER` does not return anything. The cursor just drops to new line.

![inf-clojure-unresponsive-repl-windows-os](https://cloud.githubusercontent.com/assets/3253772/5761851/bfca6d1a-9d10-11e4-95b0-49e0a0310d46.png)

I found the solution here https://groups.google.com/forum/#!topic/leiningen/48M-xvcI2Ng.

Basically, just create file `.jline.rc` and put this line on this file.

`jline.terminal=unsupported`

I don't know where to put it. So, I decided just to add Troubleshooting section in README.md
