### PR TITLE
Add new-line mark after inf-clojure-arglist-command

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -443,7 +443,7 @@ Used by this command to determine defaults."
       (clojure.core/meta
        (clojure.core/resolve
         (clojure.core/read-string \"%s\"))))
-     (catch Throwable t nil))"
+     (catch Throwable t nil))\n"
   "Command to query inferior Clojure for a function's arglist.")
 
 (defvar inf-clojure-completion-command


### PR DESCRIPTION
I tried to use `C-c C-a` as the inf-clojure-show-arglist command, then I couldn't see any output.
I'm not sure, but maybe this command needed new-line mark after that command.
Thanks.