### PR TITLE
Switch to repl is optional when load file

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -436,7 +436,8 @@ Used by this command to determine defaults."
                                             (file-name-nondirectory file-name)))
   (comint-send-string (inf-clojure-proc)
                       (format inf-clojure-load-command file-name))
-  (inf-clojure-switch-to-repl t))
+  (when current-prefix-arg
+    (inf-clojure-switch-to-repl t)))
 
 (defun inf-clojure-connected-p ()
   "Return t if inferior Clojure is currently connected, nil otherwise."


### PR DESCRIPTION
This commit adds current-prefix-arg check before switch to repl. So one
can use C-u M-x inf-clojure-load-file to switch to repl