### PR TITLE
Accept cons pair for tcp connections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Add the following to your Emacs config to enable
 (add-hook 'clojure-mode-hook #'inf-clojure-minor-mode)
 ```
 
+`inf-clojure-program` is a custom variable that defines a program to run
+or the tcp socket to connect to when starting `inf-clojure`. By default
+this var is set to `lein repl`, which will start a repl via leiningen.
+However, it is possible to use a cons pair like `("localhost" . 5555)` to
+connect to a socket repl like the one provided with [planck](http://planck-repl.org/),
+which can be started from the command line with `planck -n 5555`.
+
 **Don't enable `inf-clojure-minor-mode` and `cider-mode` at the same
 time.  They have overlapping functionality and keybindings and the
 result will be nothing short of havoc.**

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -139,8 +139,11 @@ The following commands are available:
                #'inf-clojure-completion-at-point))
 
 (defcustom inf-clojure-program "lein repl"
-  "Program name for invoking an inferior Clojure in Inferior Clojure mode."
-  :type 'string
+  "Either a program name or a connection cons pair consisting of a host
+and port number (e.g. (\"localhost\" . 5555)), for invoking an inferior Clojure
+in Inferior Clojure mode."
+  :type '(choice (string)
+                 (cons string integer))
   :group 'inf-clojure)
 
 (defcustom inf-clojure-load-command "(clojure.core/load-file \"%s\")\n"
@@ -322,7 +325,9 @@ of `inf-clojure-program').  Runs the hooks from
   (if (not (comint-check-proc "*inf-clojure*"))
       ;; run the new process in the project's root when in a project folder
       (let ((default-directory (inf-clojure-project-root))
-            (cmdlist (split-string cmd)))
+            (cmdlist (if (consp cmd)
+                         (list cmd)
+                       (split-string cmd))))
         (set-buffer (apply #'make-comint
                            "inf-clojure" (car cmdlist) nil (cdr cmdlist)))
         (inf-clojure-mode)))


### PR DESCRIPTION
Coming takes a cons pair for connecting to tcp connections. This allows `inf-clojure` (or setting `inf-clojure-program`) to accept a cons pair for connecting to a clojure socket repl server. I tested this with planck via `planck -n 5555`.