### PR TITLE
Support REPL flavors and Lumo

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -158,7 +158,7 @@ The following commands are available:
 (defcustom inf-clojure-lein-cmd "lein repl"
   "The command used to start a Clojure REPL for Leiningen projects.
 
-Alternative you can specify a TCP connection cons pair, instead
+Alternatively you can specify a TCP connection cons pair, instead
 of command, consisting of a host and port
 number (e.g. (\"localhost\" . 5555)).  That's useful if you're
 often connecting to a remote REPL process."
@@ -168,7 +168,7 @@ often connecting to a remote REPL process."
 (defcustom inf-clojure-boot-cmd "boot repl"
   "The command used to start a Clojure REPL for Boot projects.
 
-Alternative you can specify a TCP connection cons pair, instead
+Alternatively you can specify a TCP connection cons pair, instead
 of command, consisting of a host and port
 number (e.g. (\"localhost\" . 5555)).  That's useful if you're
 often connecting to a remote REPL process."
@@ -178,7 +178,7 @@ often connecting to a remote REPL process."
 (defcustom inf-clojure-generic-cmd "lein repl"
   "The command used to start a Clojure REPL outside Lein/Boot projects.
 
-Alternative you can specify a TCP connection cons pair, instead
+Alternatively you can specify a TCP connection cons pair, instead
 of command, consisting of a host and port
 number (e.g. (\"localhost\" . 5555)).  That's useful if you're
 often connecting to a remote REPL process."

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -332,6 +332,7 @@ to continue it."
   (setq comint-input-filter #'inf-clojure-input-filter)
   (setq-local comint-prompt-read-only inf-clojure-prompt-read-only)
   (add-hook 'comint-preoutput-filter-functions #'inf-clojure-preoutput-filter nil t)
+  (add-hook 'comint-output-filter-functions 'inf-clojure--ansi-filter)
   (add-hook 'completion-at-point-functions #'inf-clojure-completion-at-point nil t)
   (ansi-color-for-comint-mode-on))
 
@@ -355,6 +356,19 @@ to continue it."
 (defun inf-clojure-remove-subprompts (string)
   "Remove subprompts from STRING."
   (replace-regexp-in-string inf-clojure-subprompt "" string))
+
+(defconst inf-clojure--ansi-clear-line "\\[1G\\|\\[0J\\|\\[13G"
+  "Ansi codes sent by the lumo repl that we need to clear." )
+
+(defun inf-clojure--ansi-filter (string)
+  "Filter unwanted ansi character from STRING."
+  (save-excursion
+    ;; go to start of first line just inserted
+    (comint-goto-process-mark)
+    (goto-char (max (point-min) (- (point) (string-width string))))
+    (forward-line 0)
+    (while (re-search-forward inf-clojure--ansi-clear-line nil t)
+      (replace-match ""))))
 
 (defun inf-clojure-preoutput-filter (str)
   "Preprocess the output STR from interactive commands."


### PR DESCRIPTION
This patch adds the `inf-clojure-repl-flavor` defcustom in order to
support different kind of configurations based on the selected flavor.
The default flavor is `'clojure`, and the other supported one is `'lumo`.
It also adds defcustoms to further customize hostname, port and
classpath used in the Lumo flavor.

--

The defcustoms for the following are already ok:
 * `inf-clojure-set-ns-form`
 * `inf-clojure-macroexpand-form`
 * `inf-clojure-macroexpand-1-form`

TODOs
 * `(setq inf-clojure-var-source-form "(lumo.repl/source %s)")` - https://github.com/anmonteiro/lumo/issues/84
 * `(setq inf-clojure-ns-vars-form "(lumo.repl/dir %s)")` - https://github.com/anmonteiro/lumo/issues/87
 * `(setq inf-clojure-var-apropos-form "(lumo.repl/apropos %s)")` - https://github.com/anmonteiro/lumo/issues/86
 * `(setq inf-clojure-arglist-form "(lumo.repl/get-arglists \"%s\")")` - https://github.com/anmonteiro/lumo/pull/88
