### PR TITLE
Fix prompt being included in input history

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -167,6 +167,13 @@ to load that file."
   :type 'regexp
   :group 'inf-clojure)
 
+(defcustom inf-clojure-comint-prompt-regexp "^\\( *#_\\|[^=> \n]+\\)=> *"
+  "Regexp to recognize both main prompt and subprompt for comint.
+This should usually be a combination of `inf-clojure-prompt' and
+`inf-clojure-subprompt'."
+  :type 'regexp
+  :group 'inf-clojure)
+
 (defvar inf-clojure-buffer nil
   "The current inf-clojure process buffer.
 
@@ -253,7 +260,7 @@ If `comint-use-prompt-regexp' is nil (the default), \\[comint-insert-input] on o
 Paragraphs are separated only by blank lines.  Semicolons start comments.
 If you accidentally suspend your process, use \\[comint-continue-subjob]
 to continue it."
-  (setq comint-prompt-regexp inf-clojure-prompt)
+  (setq comint-prompt-regexp inf-clojure-comint-prompt-regexp)
   (setq mode-line-process '(":%s"))
   (clojure-mode-variables)
   (inf-clojure-eldoc-setup)
@@ -268,7 +275,7 @@ to continue it."
   (save-excursion
     (let ((end (point)))
       (backward-sexp)
-      (buffer-substring (point) end))))
+      (buffer-substring (max (point) (comint-line-beginning-position)) end))))
 
 (defun inf-clojure-input-filter (str)
   "Return t if STR does not match `inf-clojure-filter-regexp'."


### PR DESCRIPTION
When navigating to previous input history and *current input is empty*,
the `backward-sexp' call in function `inf-clojure-get-old-input' would
not respect comint prompt boundary and jump to beginning of line. This
caused the prompt text to be stored in `comint-stored-incomplete-input',
which is annoying and causes even more problems if prompt text is set to
read-only.

This change makes sure that the extracted buffer substring for current
input does not include the prompt, even when input is empty or just
white space.

Also, introduce a regexp to use for `comint-prompt-regexp' which matches
both main prompt and sub prompts, so that boundary is respected when
`comint-use-prompt-regexp' is set to t.

Fixes #35