### PR TITLE
Add defcustom `inf-clojure-prompt-when-set-ns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 * [#34](https://github.com/clojure-emacs/inf-clojure/pull/34): Add support for socket REPL connections.
+* [#46](https://github.com/clojure-emacs/inf-clojure/pull/46): Make it possible to disable prompt on `inf-clojure-set-ns`.
 * New interactive command `inf-clojure-display-version`.
 
 ### Bugs Fixed

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -179,6 +179,12 @@ This should usually be a combination of `inf-clojure-prompt' and
   :type 'regexp
   :group 'inf-clojure)
 
+(defcustom inf-clojure-prompt-on-set-ns t
+  "Controls whether to prompt when switching namespace."
+  :type '(choice (const :tag "always" t)
+                 (const :tag "never" nil))
+  :group 'inf-clojure)
+
 (defvar inf-clojure-buffer nil
   "The current inf-clojure process buffer.
 
@@ -620,8 +626,13 @@ See variable `inf-clojure-ns-vars-command'."
 
 (defun inf-clojure-set-ns (ns)
   "Set the ns of the inferior Clojure process to NS.
-Defaults to the ns of the current buffer."
-  (interactive (inf-clojure-symprompt "Set ns to" (clojure-find-ns)))
+Defaults to the ns of the current buffer, always prompting before
+setting, unless `inf-clojure-prompt-on-set-ns` is nil."
+  (interactive (list (if inf-clojure-prompt-on-set-ns
+                         (inf-clojure-symprompt "Set ns to" (clojure-find-ns))
+                       (clojure-find-ns))))
+  (when (or (not ns) (equal ns ""))
+    (user-error "No namespace selected"))
   (comint-proc-query (inf-clojure-proc) (format inf-clojure-set-ns-command ns)))
 
 (defun inf-clojure-apropos (var)


### PR DESCRIPTION
The patch allow the user to disable the request "Set ns: ..." on C-c
M-n. The default is to always prompt.

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)

(No need?) -> You've updated the readme (if adding/changing user-visible functionality)
