### PR TITLE
Rename to -form where appropriate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features
 
+* [#50](https://github.com/clojure-emacs/inf-clojure/pull/50): Rename defcustoms to `inf-clojure-*-form` where appropriate.
 * [#34](https://github.com/clojure-emacs/inf-clojure/pull/34): Add support for socket REPL connections.
 * [#46](https://github.com/clojure-emacs/inf-clojure/pull/46): Make it possible to disable prompt on `inf-clojure-set-ns`.
 * New interactive command `inf-clojure-display-version`.


### PR DESCRIPTION
This patch renames all the inf-clojure-*-command defcustoms to
inf-clojure-*-form where the content is a Clojure form to be evaluated
at the REPL.