### PR TITLE
Add inf-clojure-prompt-on-commands and closes #48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@
 
 ### New Features
 
+* [#51](https://github.com/clojure-emacs/inf-clojure/pull/51): Commands do not prompt by default anymore, unless they receive a non-nil prefix argument.
 * [#44](https://github.com/clojure-emacs/inf-clojure/pull/44): Add REPL types and Lumo support.
 * [#50](https://github.com/clojure-emacs/inf-clojure/pull/50): Rename defcustoms to `inf-clojure-*-form` where appropriate.
 * [#34](https://github.com/clojure-emacs/inf-clojure/pull/34): Add support for socket REPL connections.
-* [#46](https://github.com/clojure-emacs/inf-clojure/pull/46): Make it possible to disable prompt on `inf-clojure-set-ns`.
 * New interactive command `inf-clojure-display-version`.
 * [#42](https://github.com/clojure-emacs/inf-clojure/issues/42): Add a defcustom controlling the window in which the REPL buffer is displayed (`inf-clojure-repl-use-same-window`).
 * Font-lock the code in the REPL.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ the default specified in `inf-clojure-program`.
 You can set custom values to `inf-clojure` variables on a per-project basis using [directory
 variables](https://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html).
 
+The REPL commands don't prompt by default but a prefix argument will invert
+this. For instance: `C-u C-c C-v` will ask for the symbol you want to show the
+docstring for.
+
 ## REPL Type
 
 An `inf-clojure` REPL can be of different types: Clojure, ClojureScript, Lumo and Planck are all potentially valid options.


### PR DESCRIPTION
The patch introduces a way to globally disable prompting. It deletes
`inf-clojure-prompt-when-set-ns`.

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the README

