### PR TITLE
Fix repl type sync

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -195,17 +195,23 @@ often connecting to a remote REPL process."
 Its root binding is nil and it can be further customized using
 either `setq-local` or an entry in `.dir-locals.el`." )
 
-(defun inf-clojure--detect-type (proc)
+(defvar inf-clojure--repl-type-lock nil
+  "Global lock for protecting against proc filter race conditions.
+See http://blog.jorgenschaefer.de/2014/05/race-conditions-in-emacs-process-filter.html")
+
+(defun inf-clojure--detect-repl-type (proc)
   "Identifies the current REPL type for PROC."
-  (cond
-   ((inf-clojure--lumo-p proc) 'lumo)
-   (t 'clojure)))
+  (when (not inf-clojure--repl-type-lock)
+    (let ((inf-clojure--repl-type-lock t))
+      (cond
+       ((inf-clojure--lumo-p proc) 'lumo)
+       (t 'clojure)))))
 
 (defun inf-clojure--set-repl-type (proc)
   "Set the REPL type if has not already been set.
 It requires a REPL PROC for inspecting the correct type."
   (if (not inf-clojure-repl-type)
-      (setq inf-clojure-repl-type (inf-clojure--detect-type proc))
+      (setq inf-clojure-repl-type (inf-clojure--detect-repl-type proc))
     inf-clojure-repl-type))
 
 (defun inf-clojure--send-string (proc string)

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -202,9 +202,11 @@ either `setq-local` or an entry in `.dir-locals.el`." )
    (t 'clojure)))
 
 (defun inf-clojure--set-repl-type (proc)
-  "Set the REPL type if has not already been set."
-  (when (not inf-clojure-repl-type)
-    (setq inf-clojure-repl-type (inf-clojure--detect-type proc))))
+  "Set the REPL type if has not already been set.
+It requires a REPL PROC for inspecting the correct type."
+  (if (not inf-clojure-repl-type)
+      (setq inf-clojure-repl-type (inf-clojure--detect-type proc))
+    inf-clojure-repl-type))
 
 (defun inf-clojure--send-string (proc string)
   "A custom `comint-input-sender` / `comint-send-string`.
@@ -584,7 +586,7 @@ The prefix argument SWITCH-TO-REPL controls whether to switch to REPL after the 
   "Return the form to query inferior Clojure for a var's documentation.
 If you are using REPL types, it will pickup the most approapriate
 `inf-clojure-var-doc-form` variant."
-  (pcase inf-clojure-repl-type
+  (pcase (inf-clojure--set-repl-type (inf-clojure-proc))
     (`lumo inf-clojure-var-doc-form-lumo)
     (_ inf-clojure-var-doc-form)))
 
@@ -627,7 +629,7 @@ If you are using REPL types, it will pickup the most approapriate
   "Return the form to query inferior Clojure for a var's documentation.
 If you are using REPL types, it will pickup the most approapriate
 `inf-clojure-completion-form` variant."
-  (pcase inf-clojure-repl-type
+  (pcase (inf-clojure--set-repl-type (inf-clojure-proc))
     (`lumo inf-clojure-completion-form-lumo)
     (_ inf-clojure-completion-form)))
 


### PR DESCRIPTION
I opened this PR basically to raise a flag around synchronicity and asking for what is the best way to solve them. It is a very sporadic problem I get when I try to detect the REPL type while waiting for a REPL detection that finishes. As you can imagine these things are difficult to reproduce and I'd like to ask folks to try `inf-clojure` without this patch in `lumo` and report what happens.

I found http://blog.jorgenschaefer.de/2014/05/race-conditions-in-emacs-process-filter.html and put a lock in there, which is a hack.

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
