### PR TITLE
Officially support lumo -d (dumb terminal) only

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ At the moment, the default Clojure REPL and the Lumo REPL (though partially, see
 To hook up a custom REPL type, just use the right launch command (or connect through socket).
 For example, for Lumo just add the following in your `.dir-locals.el`:
 
-    ((nil . ((inf-clojure-boot-cmd . "lumo")))) ;; inf-clojure-lein-cmd if you are using Leiningen
+    ((nil . ((inf-clojure-boot-cmd . "lumo -d")))) ;; inf-clojure-lein-cmd if you are using Leiningen
 
 ## ElDoc
 
@@ -103,6 +103,15 @@ following to you Emacs config:
 
 ElDoc currently doesn't work with ClojureScript buffers and REPL's.
 You can leave it enabled, it just won't show anything in the echo area.
+
+## Lumo Setup
+
+For an optimal Lumo experience the `-d` needs to be passed to Lumo when launched from the command line. This disable `readline` support in order to play nicely with emacs.
+
+For example, you can use the following command (assuming `cp` contains the classpath) in your `.dir-locals.el`:
+
+((nil . (eval . (setq inf-clojure-boot-cmd (concat "lumo -d -c "
+                                                    (f-read (concat (inf-clojure-project-root) "cp")))))))
 
 ## Troubleshooting
 

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -1025,7 +1025,7 @@ for evaluation, therefore FORM should not include it."
   (apply-partially 'inf-clojure--response-match-p
                    inf-clojure--lumo-repl-form
                    (lambda (string)
-                     (string-match-p (concat inf-clojure--lumo-repl-form "\\Ca*true\\Ca*") string)))
+                     (string-match-p "\\Ca*true\\Ca*" string)))
   "Ascertain that PROC is a Lumo REPL.")
 
 (provide 'inf-clojure)

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -336,7 +336,6 @@ to continue it."
   (setq comint-input-filter #'inf-clojure-input-filter)
   (setq-local comint-prompt-read-only inf-clojure-prompt-read-only)
   (add-hook 'comint-preoutput-filter-functions #'inf-clojure-preoutput-filter nil t)
-  (add-hook 'comint-output-filter-functions 'inf-clojure--ansi-filter)
   (add-hook 'completion-at-point-functions #'inf-clojure-completion-at-point nil t)
   (ansi-color-for-comint-mode-on))
 
@@ -360,19 +359,6 @@ to continue it."
 (defun inf-clojure-remove-subprompts (string)
   "Remove subprompts from STRING."
   (replace-regexp-in-string inf-clojure-subprompt "" string))
-
-(defconst inf-clojure--ansi-clear-line "\\[1G\\|\\[0J\\|\\[13G"
-  "Ansi codes sent by the lumo repl that we need to clear." )
-
-(defun inf-clojure--ansi-filter (string)
-  "Filter unwanted ansi character from STRING."
-  (save-excursion
-    ;; go to start of first line just inserted
-    (comint-goto-process-mark)
-    (goto-char (max (point-min) (- (point) (string-width string))))
-    (forward-line 0)
-    (while (re-search-forward inf-clojure--ansi-clear-line nil t)
-      (replace-match ""))))
 
 (defun inf-clojure-preoutput-filter (str)
   "Preprocess the output STR from interactive commands."


### PR DESCRIPTION
This patch supports lumo -d (dumb terminal) and suggests in the README a
command to launch it this way.

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)

