### PR TITLE
[Fix #58] Add function to connect to remote repl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## master (unreleased)
 
 ### New Features
-
+* [#57](https://github.com/clojure-emacs/inf-clojure/pull/68): Add `inf-clojure-connect`
 * [#66](https://github.com/clojure-emacs/inf-clojure/pull/56): Add Planck support.
 * [#51](https://github.com/clojure-emacs/inf-clojure/pull/51): Commands do not prompt by default anymore, unless they receive a non-nil prefix argument.
 * [#44](https://github.com/clojure-emacs/inf-clojure/pull/44): Add REPL types and Lumo support.

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ The REPL commands don't prompt by default but a prefix argument will invert
 this. For instance: `C-u C-c C-v` will ask for the symbol you want to show the
 docstring for.
 
+You can use `M-x inf-clojure-connect` to connect to a running socket-repl.
+You will be prompted for host and port.
+
 ## REPL Type
 
 An `inf-clojure` REPL can be of different types: Clojure, ClojureScript, Lumo and Planck are all potentially valid options.

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -467,6 +467,13 @@ of `inf-clojure-*-cmd').  Runs the hooks from
       (pop-to-buffer-same-window "*inf-clojure*")
     (pop-to-buffer "*inf-clojure*")))
 
+;;;###autoload
+(defun inf-clojure-connect (host port)
+  "Connect to a running socket-repl via `inf-clojure'.
+HOST is the host the process is running on, PORT is where it's listening."
+  (interactive "shost: \nnport: ")
+  (inf-clojure (cons host port)))
+
 (defun inf-clojure-eval-region (start end &optional and-go)
   "Send the current region to the inferior Clojure process.
 Prefix argument AND-GO means switch to the Clojure buffer afterwards."


### PR DESCRIPTION
Add new interactive command to connect to a socket-repl

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md