### PR TITLE
make case when nil is a string

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -981,6 +981,7 @@ See variable `inf-clojure-arglists-form'."
          (arglists-data (when arglists-result (read arglists-result))))
     (cond
      ((null arglists-data) nil)
+     ((string-equal arglists-data "nil") nil)
      ((stringp arglists-data) arglists-data)
      ((listp arglists-data) arglists-result))))
 

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -703,7 +703,8 @@ If you are using REPL types, it will pickup the most approapriate
 (define-obsolete-variable-alias 'inf-clojure-arglist-command 'inf-clojure-arglists-form "2.0.0")
 
 (defcustom inf-clojure-arglists-form-lumo
-  "(pr-str (lumo.repl/get-arglists \"%s\"))"
+  "(when-let [res (lumo.repl/get-arglists \"%s\")] 
+       (-> res str clojure.string/trim))"
   "Lumo form to query inferior Clojure for a function's arglists."
   :type 'string
   :package-version '(inf-clojure . "2.0.0"))
@@ -981,9 +982,10 @@ See variable `inf-clojure-arglists-form'."
          (arglists-data (when arglists-result (read arglists-result))))
     (cond
      ((null arglists-data) nil)
-     ((string-equal arglists-data "nil") nil)
      ((stringp arglists-data) arglists-data)
-     ((listp arglists-data) arglists-result))))
+     ((and (listp arglists-data)
+           (not (string-equal inf-clojure-repl-type "lumo")))
+      arglists-result))))
 
 (defun inf-clojure-show-arglists (prompt-for-symbol)
   "Show the arglists for function FN in the mini-buffer.


### PR DESCRIPTION
I'm getting eldocs in lumo for symbol: nil, that's due to
line 1170:
` (value (inf-clojure-eldoc-arglists thing))`
returning "nil" as string so `when` is always getting truthy value.

Adding case of "nil" as string fixes this, but I guess this string "nil" is the return value from lumo.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x ] The commits are consistent with our [contribution guidelines][1]
- [x ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
