### PR TITLE
add callback argument to lumo get-completions

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -726,7 +726,10 @@ If you are using REPL types, it will pickup the most approapriate
 (define-obsolete-variable-alias 'inf-clojure-completion-command 'inf-clojure-completion-form "2.0.0")
 
 (defcustom inf-clojure-completion-form-lumo
-  "(doall (map str (lumo.repl/get-completions \"%s\")))"
+  "(let [ret (atom)]
+     (lumo.repl/get-completions \"%s\"
+       (fn [res] (reset! ret (map str res))))
+     @ret)"
   "Lumo form to query inferior Clojure for completion candidates."
   :type 'string
   :package-version '(inf-clojure . "2.0.0"))


### PR DESCRIPTION
lumo.repl/get-completions takes two arguments.
https://github.com/anmonteiro/lumo/blob/master/src/cljs/snapshot/lumo/repl.cljs#L1252
So I added map str function into the callback, now I'm getting completions suggestions from company-mode.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x ] The commits are consistent with our [contribution guidelines][1]
- [x ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
