### PR TITLE
Introduce inf-clojure-log-activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,16 @@ directory and add this line to that file:
 jline.terminal=unsupported
 ```
 
+### Log process activity
+
+Standard Emacs debugging turns out to be difficult when an asynchronous process is involved. In this case try to enable logging:
+
+```el
+(setq inf-clojure-log-activity t)
+```
+
+This creates `.inf-clojure.log` in the process root for you to `tail -f` on.
+
 ## License
 
 Copyright © 2014-2017 Bozhidar Batsov and [contributors][].


### PR DESCRIPTION
Log commands and responses from/to the Inf-Clojure process. It can be enabled with `(setq inf-clojure-log-activity t)`. Vital for debugging.

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the readme (if adding/changing user-visible functionality)