### PR TITLE
Fix #89 and speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * [#79](https://github.com/clojure-emacs/inf-clojure/pull/82): Eldoc error when running boot repl.
 * [#83](https://github.com/clojure-emacs/inf-clojure/pull/85): No such namespace: complete.core in lumo REPL.
+* [#93](https://github.com/clojure-emacs/inf-clojure/pull/93): Slow response from inf-clojure (completions, arglists, ...).
 
 ## 2.0.1 (2017-05-18)
 

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -958,14 +958,16 @@ Inf-Clojure will create a log file in the project folder named
 `inf-clojure--log-file-name' and dump the process activity in it
 in case this is not nil." )
 
-(defun inf-clojure--log-string (string &optional type)
+(defun inf-clojure--log-string (string &optional tag)
   "Log STRING to file, according to `inf-clojure-log-response'.
 The optional TYPE will be converted to string and printed before
 STRING if present."
   (when inf-clojure-log-activity
     (write-region (concat "\n"
-                          (when type
-                            (concat (prin1-to-string type) " | "))
+                          (when tag
+                            (if (stringp tag)
+                              (concat tag "\n")
+                              (concat (prin1-to-string tag) "\n")))
                           (let ((print-escape-newlines t))
                             (prin1-to-string string)))
                   nil
@@ -984,7 +986,7 @@ string will start from (point) in the results buffer.  If
 END-STRING is nil, the result string will end at (point-max) in
 the results buffer.  It cuts out the output from and including
 the `inf-clojure-prompt`."
-  (inf-clojure--log-string command :cmd)
+  (inf-clojure--log-string command "----CMD->")
   (let ((work-buffer inf-clojure--redirect-buffer-name))
     (save-excursion
       (set-buffer (get-buffer-create work-buffer))
@@ -1007,7 +1009,7 @@ the `inf-clojure-prompt`."
              (prompt (when (search-forward inf-clojure-prompt nil t)
                        (match-beginning 0)))
              (buffer-string (buffer-substring-no-properties beg (or prompt end))))
-        (inf-clojure--log-string buffer-string :res)
+        (inf-clojure--log-string buffer-string "<-RES----")
         buffer-string))))
 
 (defun inf-clojure--nil-string-match-p (string)

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -995,8 +995,9 @@ the `inf-clojure-prompt`."
        (inf-clojure--sanitize-command command) work-buffer process nil t)
       ;; Wait for the process to complete
       (set-buffer (process-buffer process))
-      (while (null comint-redirect-completed)
-        (accept-process-output nil 1))
+      (while (and (null comint-redirect-completed)
+                  (accept-process-output process 1 0 t))
+        (sleep-for 0.01))
       ;; Collect the output
       (set-buffer work-buffer)
       (goto-char (point-min))


### PR DESCRIPTION
Introduce double checking in the busy wait that detects if the inf-clojure process (the REPL) has completed and sent back everything. This removes the slowness that was triggered by having accept-process-output in the while body: we can take advantage now of its output to wait as well.

-----------------

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
