### PR TITLE
Be compatible with older Emacs

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -1056,8 +1056,8 @@ readable sexp only."
   "Eval MATCH-P on the response of sending to PROC the input FORM.
 Note that this function will add a \n to the end of the string
 for evaluation, therefore FORM should not include it."
-  (when-let ((response (inf-clojure--process-response form proc)))
-    (funcall match-p response)))
+  (let ((response (inf-clojure--process-response form proc)))
+    (when response (funcall match-p response))))
 
 (defun inf-clojure--some-response-p (proc form)
   "Return true iff PROC's response after evaluating FORM is not nil."


### PR DESCRIPTION
For now only one thing has been done:

 * Split the only when-let for backward compatibility

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)

Did not update the CHANGELOG in order to wait if this is the only thing to do.