### PR TITLE
add expression break chars

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -1220,7 +1220,7 @@ See variable `inf-clojure-buffer'."
       (inf-clojure--read-or-nil)
       (inf-clojure--list-or-nil))))
 
-(defconst inf-clojure-clojure-expr-break-chars " \t\n\"\'`><,;|&{(")
+(defconst inf-clojure-clojure-expr-break-chars " \t\n\"\'`><,;|&{()[]")
 
 (defun inf-clojure-completion-bounds-of-expr-at-point ()
   "Return bounds of expression at point to complete."
@@ -1228,7 +1228,9 @@ See variable `inf-clojure-buffer'."
     (save-excursion
       (let ((end (point)))
         (skip-chars-backward (concat "^" inf-clojure-clojure-expr-break-chars))
-        (cons (point) end)))))
+        (let ((first-char (substring-no-properties (thing-at-point 'symbol) 0 1)))
+          (when (string-match-p "[^0-9]" first-char)
+            (cons (point) end)))))))
 
 (defun inf-clojure-completion-expr-at-point ()
   "Return expression at point to complete."


### PR DESCRIPTION
To not get weird completions the expression boundries cant contain open or close parenthesis and open or close brackets. Otherwise, in the case of lumo, the completions will look like the following picture.

https://user-images.githubusercontent.com/6074754/27034766-3de33bbe-4f7f-11e7-821f-62204cd9f02d.png

So far after adding these chars I've not experienced this again.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x ] The commits are consistent with our [contribution guidelines][1]
- [x ] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
