### PR TITLE
Fix bug introduced by #105

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -774,7 +774,7 @@ If you are using REPL types, it will pickup the most approapriate
   :package-version '(inf-clojure . "2.0.0"))
 
 (defcustom inf-clojure-arglists-form-planck
-  "(planck.repl/get-arglists \"%s\""
+  "(planck.repl/get-arglists \"%s\")"
   "Planck form to query inferior Clojure for a function's arglists."
   :type 'string
   :safe #'stringp


### PR DESCRIPTION
In the work I did with #105, I missed a closing paren, which caused inf-clojure with Planck to misbehave.

- [√ ] The commits are consistent with our [contribution guidelines][1]
- [√ ] The new code is not generating bytecode or `M-x checkdoc` warnings
