### PR TITLE
Introduce inf-clojure-project-type defcustom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 * [#93](https://github.com/clojure-emacs/inf-clojure/pull/93): Slow response from inf-clojure (completions, arglists, ...).
 * [#101](https://github.com/clojure-emacs/inf-clojure/pull/101): `inf-clojure-set-ns` hangs Emacs.
 
+### New Features
+
+* [#114](https://github.com/clojure-emacs/inf-clojure/pull/114): Introduce `inf-clojure-project-type` defcustom.
+
 ## 2.0.1 (2017-05-18)
 
 ### Bugs Fixed

--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ interacting with it.
 `inf-clojure` has several custom variables which control the command
 used to start a REPL for particular project type - `inf-clojure-lein-cmd`,
 `inf-clojure-boot-cmd` and `inf-clojure-generic-cmd`.
+The `inf-clojure-project-type` can force a particular project type, skipping
+the project detection, which can be useful for projects that don't have
+standard layouts.
 
 By default all those variables are set to strings (e.g. `lein repl`).
 However, it is possible to use a cons pair like `("localhost" . 5555)`

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -189,6 +189,14 @@ number (e.g. (\"localhost\" . 5555))."
    (stringp (car x))
    (numberp (cdr x))))
 
+(defcustom inf-clojure-project-type nil
+  "Defines the project type.
+
+If this is `nil`, the project will be automatically detected."
+  :type 'string
+  :safe #'stringp
+  :package-version '(inf-clojure . "2.1.0"))
+
 (defcustom inf-clojure-lein-cmd "lein repl"
   "The command used to start a Clojure REPL for Leiningen projects.
 
@@ -511,10 +519,11 @@ Fallback to `default-directory.' if not within a project."
 
 (defun inf-clojure-project-type ()
   "Determine the type, either leiningen or boot of the current project."
-  (let ((default-directory (inf-clojure-project-root)))
-    (cond ((file-exists-p "project.clj") "lein")
-          ((file-exists-p "build.boot") "boot")
-          (t nil))))
+  (or inf-clojure-project-type
+      (let ((default-directory (inf-clojure-project-root)))
+        (cond ((file-exists-p "project.clj") "lein")
+              ((file-exists-p "build.boot") "boot")
+              (t "generic")))))
 
 (defun inf-clojure-cmd (project-type)
   "Determine the command `inf-clojure' needs to invoke for the PROJECT-TYPE."


### PR DESCRIPTION
This patch adds a defcustom, inf-clojure-skip-project-detection, that when
non-nil skips the project detection so that only inf-clojure-generic-cmd will
be used.  This is very useful for projects that don't have standard layouts.

-----------------

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)