### PR TITLE
 [Fix #116] Set inf-clojure-buffer REPL type on detect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [#83](https://github.com/clojure-emacs/inf-clojure/pull/85): No such namespace: complete.core in lumo REPL.
 * [#93](https://github.com/clojure-emacs/inf-clojure/pull/93): Slow response from inf-clojure (completions, arglists, ...).
 * [#101](https://github.com/clojure-emacs/inf-clojure/pull/101): `inf-clojure-set-ns` hangs Emacs.
+* [#119](https://github.com/clojure-emacs/inf-clojure/pull/119): Set inf-clojure-buffer REPL type on detect.
 * [#120](https://github.com/clojure-emacs/inf-clojure/pull/120): Send REPL string always, even if empty.
 
 ### New Features

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -292,9 +292,10 @@ See http://blog.jorgenschaefer.de/2014/05/race-conditions-in-emacs-process-filte
 (defun inf-clojure--set-repl-type (proc)
   "Set the REPL type if has not already been set.
 It requires a REPL PROC for inspecting the correct type."
-  (if (not inf-clojure-repl-type)
-      (setq inf-clojure-repl-type (inf-clojure--detect-repl-type proc))
-    inf-clojure-repl-type))
+  (with-current-buffer inf-clojure-buffer
+    (if (not inf-clojure-repl-type)
+        (setq inf-clojure-repl-type (inf-clojure--detect-repl-type proc))
+      inf-clojure-repl-type)))
 
 (defun inf-clojure--single-linify (string)
   "Convert a multi-line STRING in a single-line STRING.


### PR DESCRIPTION
Now the code sets the `inf-clojure-repl-type` buffer local var in the `inf-clojure-buffer` when a REPL type is detected. This solves the weird errors that were happening when working within the REPL buffer because `inf-clojure-repl-type` is nil.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)