### PR TITLE
Fix inf-clojure-apropos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#114](https://github.com/clojure-emacs/inf-clojure/pull/114): Introduce `inf-clojure-project-type` defcustom.
 * [#117](https://github.com/clojure-emacs/inf-clojure/pull/117): Introduce `tools.deps` project type and `inf-clojure-tools-deps-cmd`.
 * [#122](https://github.com/clojure-emacs/inf-clojure/pull/122): Introduce `inf-clojure-completions-fn` defcustom.
+* [#128](https://github.com/clojure-emacs/inf-clojure/pull/128): Expose `inf-clojure-apropos` as `C-c C-S-a` in `inf-clojure-mode` (the REPL).
 
 ### Bugs Fixed
 
@@ -18,6 +19,7 @@
 * [#101](https://github.com/clojure-emacs/inf-clojure/pull/101): `inf-clojure-set-ns` hangs Emacs.
 * [#119](https://github.com/clojure-emacs/inf-clojure/pull/119): Set inf-clojure-buffer REPL type on detect.
 * [#120](https://github.com/clojure-emacs/inf-clojure/pull/120): Send REPL string always, even if empty.
+* [#128](https://github.com/clojure-emacs/inf-clojure/pull/128): Fix inf-clojure-apropos.
 
 ## 2.0.1 (2017-05-18)
 

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -1228,11 +1228,12 @@ PROMPT-FOR-NS, it prompts for a namespace name."
       (user-error "No namespace selected"))
     (inf-clojure--send-string (inf-clojure-proc) (format (inf-clojure-set-ns-form) ns))))
 
-(defun inf-clojure-apropos ()
+(defun inf-clojure-apropos (expr)
   "Send an expression to the inferior Clojure for apropos.
-See variable `inf-clojure-apropos-form'."
+EXPR can be either a regular expression or a stringable
+thing.  See variable `inf-clojure-apropos-form'."
   (interactive (inf-clojure-symprompt "Var apropos" (inf-clojure-symbol-at-point)))
-  (inf-clojure--send-string (inf-clojure-proc) (format (inf-clojure-apropos-form) var)))
+  (inf-clojure--send-string (inf-clojure-proc) (format (inf-clojure-apropos-form) expr)))
 
 (defun inf-clojure-macroexpand (&optional macro-1)
   "Send a form to the inferior Clojure for macro expansion.

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -101,6 +101,7 @@ mode.  Default is whitespace followed by 0 or 1 single-letter colon-keyword
     (define-key map "\C-c\C-a" #'inf-clojure-show-arglists)
     (define-key map "\C-c\C-v" #'inf-clojure-show-var-documentation)
     (define-key map "\C-c\C-s" #'inf-clojure-show-var-source)
+    (define-key map (kbd "C-c C-S-a") #'inf-clojure-apropos)
     (define-key map "\C-c\M-o" #'inf-clojure-clear-repl-buffer)
     (define-key map "\C-c\C-q" #'inf-clojure-quit)
     (easy-menu-define inf-clojure-mode-menu map
@@ -113,6 +114,7 @@ mode.  Default is whitespace followed by 0 or 1 single-letter colon-keyword
         ["Show arglists" inf-clojure-show-arglists t]
         ["Show documentation for var" inf-clojure-show-var-documentation t]
         ["Show source for var" inf-clojure-show-var-source t]
+        ["Apropos" inf-clojure-apropos t]
         "--"
         ["Clear REPL" inf-clojure-clear-repl-buffer]
         ["Restart" inf-clojure-restart]
@@ -132,7 +134,7 @@ mode.  Default is whitespace followed by 0 or 1 single-letter colon-keyword
     (define-key map "\C-c\C-n" #'inf-clojure-eval-form-and-next)
     (define-key map "\C-c\C-z" #'inf-clojure-switch-to-repl)
     (define-key map "\C-c\C-i" #'inf-clojure-show-ns-vars)
-    (define-key map "\C-c\C-A" #'inf-clojure-apropos)
+    (define-key map (kbd "C-c C-S-a") #'inf-clojure-apropos)
     (define-key map "\C-c\C-m" #'inf-clojure-macroexpand)
     (define-key map "\C-c\C-l" #'inf-clojure-load-file)
     (define-key map "\C-c\C-a" #'inf-clojure-show-arglists)


### PR DESCRIPTION
The functionality was erroring out cause of wrong function signature.
Moreover the key binding was not working because `C-A` is interpreted as `C-a` by
emacs (it seems, seeking Elisp expert advice).
This patch also add `C-c C-S-A` to `inf-clojure-mode` (the REPL itself).

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md