### PR TITLE
Improve the completion bounds detection (now with keywords)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+*~
+*\#*\#
+*.\#*
+*.elc
+.cask
+elpa*
+.depend
+TAGS
+.DS_STORE
+dist
+.vagrant/
+.dir-locals?.el

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: generic
+sudo: false
+before_install:
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - evm install $EVM_EMACS --use --skip
+  - cask
+env:
+  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
+  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-25.2-travis
+  - EVM_EMACS=emacs-25.3-travis
+script:
+  - emacs --version
+  - cask install
+  - cask exec buttercup -L .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * [#128](https://github.com/clojure-emacs/inf-clojure/pull/128): Expose `inf-clojure-apropos` as `C-c C-S-a` in `inf-clojure-mode` (the REPL).
 * [#125](https://github.com/clojure-emacs/inf-clojure/pull/125): Avoid throwing an error for frequent operations like completion.
 * [#130](https://github.com/clojure-emacs/inf-clojure/pull/130): Support loading directory locals in our buffers.
+* [#129](https://github.com/clojure-emacs/inf-clojure/pull/129): Improve the completion bounds detection (now with keywords).
 
 ### Bugs Fixed
 

--- a/Cask
+++ b/Cask
@@ -1,0 +1,11 @@
+(source gnu)
+(source melpa)
+
+(package-file "inf-clojure.el")
+
+(files "*.el" (:exclude ".dir-locals.el"))
+
+(development
+ (depends-on "clojure-mode")
+ (depends-on "buttercup")
+ (depends-on "assess"))

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -1344,7 +1344,7 @@ you might want to use in your customization."
   :safe #'functionp
   :package-version '(inf-clojure . "2.1.0"))
 
-(defconst inf-clojure-clojure-expr-break-chars " \t\n\"\'`><,;|&{()[]")
+(defconst inf-clojure-clojure-expr-break-chars " \t\n\"\'`><,;|&{()[]@\\^")
 
 (defun inf-clojure-completion-bounds-of-expr-at-point ()
   "Return bounds of expression at point to complete."

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -1352,9 +1352,11 @@ you might want to use in your customization."
     (save-excursion
       (let ((end (point)))
         (skip-chars-backward (concat "^" inf-clojure-clojure-expr-break-chars))
-        (let ((first-char (substring-no-properties (thing-at-point 'symbol) 0 1)))
-          (when (string-match-p "[^0-9]" first-char)
-            (cons (point) end)))))))
+        (let ((chars (thing-at-point 'symbol)))
+          (when (> (length chars) 0)
+            (let ((first-char (substring-no-properties chars 0 1)))
+              (when (string-match-p "[^0-9]" first-char)
+                (cons (point) end)))))))))
 
 (defun inf-clojure-completion-expr-at-point ()
   "Return expression at point to complete."

--- a/test/inf-clojure-tests.el
+++ b/test/inf-clojure-tests.el
@@ -1,0 +1,114 @@
+;;; inf-clojure-tests.el --- Tests for Inf-Clojure -*- lexical-binding: t; -*-
+;;
+;; Copyright © 2014-2018 Bozhidar Batsov
+
+;; Authors: Bozhidar Batsov <bozhidar@batsov.com>
+;;          Andrea Richiardi <a.richiardi.work@gmail.com>
+;; URL: http://github.com/clojure-emacs/inf-clojure
+;; Keywords: processes, clojure
+;; Package-Requires: ((emacs "24.4") (clojure-mode "5.3"))
+
+;; This file is part of GNU Emacs.
+
+;; GNU Emacs is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; GNU Emacs is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with GNU Emacs.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;
+;; Code completion using alexander-yakushev/compliment.
+
+;;; Code:
+
+;; Tests for inf-clojure.el
+
+(message "Running tests on Emacs %s" emacs-version)
+
+(require 'buttercup)
+(require 'assess)
+(require 'inf-clojure)
+
+(cl-defmacro ict-with-assess-buffers ((&rest varlist) &body body)
+  `(assess-with-temp-buffers (,@varlist)
+                             (clojure-mode)
+                             (inf-clojure-minor-mode)
+                             ,@body))
+
+(defun ict-bounds-string (bounds)
+  (buffer-substring (car bounds) (cdr bounds)))
+
+(describe "inf-clojure--kw-to-symbol"
+  (it "returns symbol form of the given keyword"
+    (expect (inf-clojure--kw-to-symbol "symbol") :to-equal "symbol")
+    (expect (inf-clojure--kw-to-symbol ":clj.core/str") :to-equal "clj.core/str")
+    (expect (inf-clojure--kw-to-symbol "::keyword") :to-equal "keyword")
+    (expect (inf-clojure--kw-to-symbol nil) :to-equal nil)))
+
+(describe "completion bounds at point" ()
+  (it "computes bounds for plain-text"
+      (ict-with-assess-buffers
+       ((a (insert "plain-text")))
+       (with-current-buffer a
+         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+                 :to-equal "plain-text"))))
+
+  (it "computes bounds for @deref"
+      (ict-with-assess-buffers
+       ((a (insert "@deref")))
+       (with-current-buffer a
+         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+                 :to-equal "deref"))))
+
+  (it "computes bounds for ^:keyword"
+      (ict-with-assess-buffers
+       ((a (insert "^:keyword")))
+       (with-current-buffer a
+         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+                 :to-equal ":keyword"))))
+
+  (it "computes bounds for ::keyword"
+      (ict-with-assess-buffers
+       ((a (insert "::keyword")))
+       (with-current-buffer a
+         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+                 :to-equal "::keyword"))))
+
+  (it "computes bounds for [^:keyword (combined break chars and keyword)"
+      (ict-with-assess-buffers
+       ((a (insert "[^:keyword")))
+       (with-current-buffer a
+         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+                 :to-equal ":keyword"))))
+
+  (it "computes no bounds for point directly after a break expression"
+      (ict-with-assess-buffers
+       ((a (insert "@")))
+       (with-current-buffer a
+         (expect
+          (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+          :not :to-be nil))))
+
+  (it "computes bounds for [symbol"
+      (ict-with-assess-buffers
+       ((a (insert "[symbol")))
+       (with-current-buffer a
+         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+                 :to-equal "symbol"))))
+
+  (it "computes bounds for (@deref (multiple break chars)"
+      (ict-with-assess-buffers
+       ((a (insert "(@deref")))
+       (with-current-buffer a
+         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+                 :to-equal "deref")))))
+
+;;; inf-clojure-tests.el ends here


### PR DESCRIPTION
It was missing, but it is actually used for identifying completions bounds.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)