### PR TITLE
Support loading directory locals in our buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#122](https://github.com/clojure-emacs/inf-clojure/pull/122): Introduce `inf-clojure-completions-fn` defcustom.
 * [#128](https://github.com/clojure-emacs/inf-clojure/pull/128): Expose `inf-clojure-apropos` as `C-c C-S-a` in `inf-clojure-mode` (the REPL).
 * [#125](https://github.com/clojure-emacs/inf-clojure/pull/125): Avoid throwing an error for frequent operations like completion.
+* [#130](https://github.com/clojure-emacs/inf-clojure/pull/130): Support loading directory locals in our buffers.
 
 ### Bugs Fixed
 

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -575,9 +575,10 @@ run).
                          (list cmd)
                        (split-string cmd))))
         (message "Starting Clojure REPL via `%s'..." cmd)
-        (set-buffer (apply #'make-comint
-                           "inf-clojure" (car cmdlist) nil (cdr cmdlist)))
-        (inf-clojure-mode)))
+        (with-current-buffer (apply #'make-comint
+                                    "inf-clojure" (car cmdlist) nil (cdr cmdlist))
+          (inf-clojure-mode)
+          (hack-dir-local-variables-non-file-buffer))))
   (setq inf-clojure-buffer "*inf-clojure*")
   (if inf-clojure-repl-use-same-window
       (pop-to-buffer-same-window "*inf-clojure*")
@@ -1108,6 +1109,17 @@ are going to match those."
             (length string))
         (or (string-match prompt string) (length string))))
 
+(defun inf-clojure--get-redirect-buffer ()
+  "Get the redirection buffer, creating it if necessary.
+
+It is the buffer used for processing REPL responses, see variable
+\\[inf-clojure--redirect-buffer-name]."
+  (or (get-buffer inf-clojure--redirect-buffer-name)
+      (let ((buffer (generate-new-buffer inf-clojure--redirect-buffer-name)))
+        (with-current-buffer buffer
+          (hack-dir-local-variables-non-file-buffer)
+          buffer))))
+
 ;; Originally from:
 ;;   https://github.com/glycerine/lush2/blob/master/lush2/etc/lush.el#L287
 (defun inf-clojure--process-response (command process &optional beg-regexp end-regexp)
@@ -1118,31 +1130,29 @@ If BEG-REGEXP is nil, the result string will start from (point)
 in the results buffer.  If END-REGEXP is nil, the result string
 will end at (point-max) in the results buffer.  It cuts out the
 output from and including the `inf-clojure-prompt`."
-  (let ((work-buffer inf-clojure--redirect-buffer-name)
+  (let ((redirect-buffer-name inf-clojure--redirect-buffer-name)
         (sanitized-command (inf-clojure--sanitize-command command)))
     (when (not (string-empty-p sanitized-command))
       (inf-clojure--log-string command "----CMD->")
-      (with-current-buffer (get-buffer-create work-buffer)
-        (erase-buffer)
-        (comint-redirect-send-command-to-process sanitized-command work-buffer process nil t)
-        ;; Wait for the process to complete
-        (set-buffer (process-buffer process))
-        (while (and (null comint-redirect-completed)
-                    (accept-process-output process 1 0 t))
-          (sleep-for 0.01))
-        ;; Collect the output
-        (set-buffer work-buffer)
-        (goto-char (point-min))
-        (let* ((buffer-string (buffer-substring-no-properties (point-min) (point-max)))
-               (boundaries (inf-clojure--string-boundaries buffer-string inf-clojure-prompt beg-regexp end-regexp))
-               (beg-pos (car boundaries))
-               (end-pos (car (cdr boundaries)))
-               (prompt-pos (car (cdr (cdr boundaries))))
-               (response-string (substring buffer-string beg-pos (min end-pos prompt-pos))))
-          (inf-clojure--log-string buffer-string "<-BUF----")
-          (inf-clojure--log-string boundaries "<-BND----")
-          (inf-clojure--log-string response-string "<-RES----")
-          response-string)))))
+      (set-buffer (inf-clojure--get-redirect-buffer))
+      (erase-buffer)
+      (comint-redirect-send-command-to-process sanitized-command redirect-buffer-name process nil t)
+      ;; Wait for the process to complete
+      (set-buffer (process-buffer process))
+      (while (and (null comint-redirect-completed)
+                  (accept-process-output process 1 0 t))
+        (sleep-for 0.01))
+      ;; Collect the output
+      (set-buffer redirect-buffer-name)
+      (goto-char (point-min))
+      (let* ((buffer-string (buffer-substring-no-properties (point-min) (point-max)))
+             (boundaries (inf-clojure--string-boundaries buffer-string inf-clojure-prompt beg-regexp end-regexp))
+             (beg-pos (car boundaries))
+             (end-pos (car (cdr boundaries)))
+             (prompt-pos (car (cdr (cdr boundaries))))
+             (response-string (substring buffer-string beg-pos (min end-pos prompt-pos))))
+        (inf-clojure--log-string buffer-string "<-RES----")
+        response-string))))
 
 (defun inf-clojure--nil-string-match-p (string)
   "Return true iff STRING is not nil.


### PR DESCRIPTION
A couple of changes to the way the redirect buffer and the main REPL buffer are
created was needed in order to have actual loading of .dir-locals.el.
Additionally, code in inf-clojure--process-response has been simplified and
corrected.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md