### PR TITLE
Introduce inf-clojure-reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#125](https://github.com/clojure-emacs/inf-clojure/pull/125): Avoid throwing an error for frequent operations like completion.
 * [#130](https://github.com/clojure-emacs/inf-clojure/pull/130): Support loading directory locals in our buffers.
 * [#129](https://github.com/clojure-emacs/inf-clojure/pull/129): Improve the completion bounds detection (now with keywords).
+* [#132](https://github.com/clojure-emacs/inf-clojure/pull/132): Introduce inf-clojure-reload.
 
 ### Bugs Fixed
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Clojure(Script) development:
 * ElDoc
 * Apropos
 * Macroexpansion
+* Require `:reload`/`:reload-all`
 * Support connecting to socket REPLs
 * Support for Lumo
 * Support for Planck


### PR DESCRIPTION
It will evaluate (require 'ns :reload) or (require 'ns :reload-all) at the
REPL, depending on the arguments passed in.

  - `C-u M-x inf-clojure-reload`: prompts for a namespace name.
  - `M-- M-x inf-clojure-reload`: executes (require ... :reload-all).
  - `M-- C-u M-x inf-clojure-reload`: reloads all AND prompts."

This works only from source buffers at the moment (like all the other namespace commands).

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [X] You've updated the readme (if adding/changing user-visible functionality)

Thanks!