### PR TITLE
Sanitation should skip comments

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -341,9 +341,8 @@ the string for evaluation.  Refer to `comint-simple-send` for
 customizations."
   (inf-clojure--set-repl-type proc)
   (let ((sanitized (inf-clojure--sanitize-command string)))
-    (when (not (string-empty-p sanitized))
-      (inf-clojure--log-string sanitized "----CMD->")
-      (comint-simple-send proc sanitized))))
+    (inf-clojure--log-string sanitized "----CMD->")
+    (comint-simple-send proc sanitized)))
 
 (defcustom inf-clojure-load-form "(clojure.core/load-file \"%s\")"
   "Format-string for building a Clojure expression to load a file.

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -305,27 +305,29 @@ It requires a REPL PROC for inspecting the correct type."
         (setq-local inf-clojure-repl-type repl-type))
     inf-clojure-repl-type))
 
-(defun inf-clojure--single-linify (string)
-  "Convert a multi-line STRING in a single-line STRING.
-It also reduces redundant whitespace for readability."
-  (thread-last string
-    (replace-regexp-in-string "[ \\|\n]+" " ")
-    (replace-regexp-in-string " $" "")))
+(defun inf-clojure--whole-comment-line-p (string)
+  "Return true iff STRING is a whole line semicolon comment."
+  (string-match-p "^\s*;" string))
 
-(defun inf-clojure--trim-newline-right (string)
-  "Trim newlines (only) in STRING."
-  (if (string-match "\n+\\'" string)
-      (replace-match "" t t string)
-    string))
+(defun inf-clojure--make-single-line (string)
+  "Convert a multi-line STRING in a single-line STRING.
+It also reduces redundant whitespace for readability and removes
+comments."
+  (let* ((lines (seq-filter (lambda (s) (not (inf-clojure--whole-comment-line-p s)))
+                            (split-string string "[\r\n]" t))))
+    (mapconcat (lambda (s)
+                 (if (not (string-match-p ";" s))
+                     (replace-regexp-in-string "\s+" " " s)
+                   (concat s "\n")))
+               lines " ")))
 
 (defun inf-clojure--sanitize-command (command)
   "Sanitize COMMAND for sending it to a process.
 An example of things that this function does is to add a final
 newline at the end of the form.  Return an empty string if the
 sanitized command is empty."
-  (let* ((linified (inf-clojure--single-linify command))
-         (sanitized (inf-clojure--trim-newline-right linified)))
-    (if (or (string-blank-p linified) (string-blank-p sanitized))
+  (let ((sanitized (inf-clojure--make-single-line command)))
+    (if (string-blank-p sanitized)
         ""
       (concat sanitized "\n"))))
 

--- a/test/inf-clojure-tests.el
+++ b/test/inf-clojure-tests.el
@@ -111,15 +111,23 @@
          (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
                  :to-equal "deref")))))
 
-(describe "inf-clojure--single-linify"
+(describe "inf-clojure--make-single-line"
   (it "replaces newlines with whitespace"
-      (expect (inf-clojure--single-linify "(do\n(println \"hello world\")\n)") :to-equal "(do (println \"hello world\") )"))
+      (expect (inf-clojure--make-single-line "(do\n(println \"hello world\")\n)") :to-equal "(do (println \"hello world\") )"))
 
   (it "does not leave whitespace at the end"
-      (expect (inf-clojure--single-linify "(do\n(println \"hello world\")\n)\n\n") :to-equal "(do (println \"hello world\") )"))
+      (expect (inf-clojure--make-single-line "(do\n(println \"hello world\")\n)\n\n") :to-equal "(do (println \"hello world\") )"))
 
-  (it "returns empty string in case of only newline"
-      (expect (inf-clojure--single-linify "\n\n\n\n") :to-equal "")))
+  (it "returns empty string when the line is only newlines"
+      (expect (inf-clojure--make-single-line "\n\n\n\n") :to-equal ""))
+
+  (it "removes comments when on their own line"
+      (expect (inf-clojure--make-single-line "(do\n(println \"hello world\")\n    ;; remove me\n)") :to-equal "(do (println \"hello world\") )"))
+
+  (it "preserves newlines of inline comments"
+      (expect (inf-clojure--make-single-line "(do\n(println \"hello world\") ;; don't remove this\n)") :to-equal "(do (println \"hello world\") ;; don't remove this\n )"))
+
+  )
 
 (describe "inf-clojure--sanitize-command"
   (it "sanitizes the command correctly"


### PR DESCRIPTION
The patch avoids removing newlines when comments are there and re-enables
sending empty commands (like in #120, how many times do I need to fix this?
:S).

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md