### PR TITLE
Use comint-send-string

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -342,7 +342,7 @@ customizations."
   (inf-clojure--set-repl-type proc)
   (let ((sanitized (inf-clojure--sanitize-command string)))
     (inf-clojure--log-string sanitized "----CMD->")
-    (comint-simple-send proc sanitized)))
+    (comint-send-string proc sanitized)))
 
 (defcustom inf-clojure-load-form "(clojure.core/load-file \"%s\")"
   "Format-string for building a Clojure expression to load a file.


### PR DESCRIPTION
This one is solving the weird duplicating prompt issue. After the sanitation
patch we were sending newline twice.  Using comint-send-string because it is
more low-level and does not modify the input string, which we are building
correctly already (hopefully).

See also https://github.com/clojure-emacs/inf-clojure/pull/138.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings