### PR TITLE
[security] Don't execute arbitrary functions

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -1417,7 +1417,6 @@ which is able to parse results in list form only.  You can peek
 at its implementation for getting to know some utility functions
 you might want to use in your customization."
   :type 'function
-  :safe #'functionp
   :package-version '(inf-clojure . "2.1.0"))
 
 (defconst inf-clojure-clojure-expr-break-chars "^[] \"'`><,;|&{()[@\\^]"


### PR DESCRIPTION
Marking all values which validate `functionp` as "safe" means that any file can potentially execute any arbitrary code on the Emacs instance it's been opened on.  This commit should remove this possibility.

PS: I don't use this package myself: I'm trying to semi-automatically detect all occurrences of this issue (`:safe 'functionp`) on all Melpa packages, so apologies for any mistakes!  

Thanks!   

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] (**Irrelevant**) You've updated the changelog (if adding/changing user-visible functionality)
- [ ]  (**Irrelevant**) You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
