### PR TITLE
[Fix #57] Add `inf-clojure-meta`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 
 * [#135](https://github.com/clojure-emacs/inf-clojure/pull/135): Improve command sanitation code.
+* [#157](https://github.com/clojure-emacs/inf-clojure/pull/157): Add `inf-clojure-meta`
 
 ## 2.1.0 (2018-01-02)
 

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -1099,6 +1099,39 @@ If you are using REPL types, it will pickup the most approapriate
 
 (define-obsolete-variable-alias 'inf-clojure-macroexpand-1-command 'inf-clojure-macroexpand-1-form "2.0.0")
 
+;;; Metadata
+;;; ===================
+(defcustom inf-clojure-meta-format
+  "(clojure.core/meta %s)"
+  "Form to retrieve metadata of another form."
+  :type 'string
+  :safe #'stringp
+  :package-version '(inf-clojure . "2.2.0"))
+
+(defcustom inf-clojure-meta-format-planck
+  "(meta %s)"
+  "Planck form to retrieve metadata of another form."
+  :type 'string
+  :safe #'stringp
+  :package-version '(inf-clojure . "2.2.0"))
+
+(defcustom inf-clojure-meta-format-lumo
+  "(meta %s)"
+  "Lumo form to retrieve metadata of another form."
+  :type 'string
+  :safe #'stringp
+  :package-version '(inf-clojure . "2.2.0"))
+
+(defun inf-clojure-meta-form (proc)
+  "Return the form for retrieving metadata in the Inf-Clojure PROC.
+If you are using REPL types, it will pickup the most appropriate
+`inf-clojure-meta-format` variant."
+  (inf-clojure--sanitize-command
+   (pcase (inf-clojure--set-repl-type proc)
+     (`lumo inf-clojure-meta-format-lumo)
+     (`planck inf-clojure-meta-format-planck)
+     (_ inf-clojure-meta-format))))
+
 ;;; Ancillary functions
 ;;; ===================
 
@@ -1344,6 +1377,15 @@ thing.  See variable `inf-clojure-apropos-form'."
   (interactive (inf-clojure-symprompt "Var apropos" (inf-clojure-symbol-at-point)))
   (let ((proc (inf-clojure-proc)))
     (inf-clojure--send-string proc (format (inf-clojure-apropos-form proc) expr))))
+
+(defun inf-clojure-meta ()
+  "Send a form to the inferior Clojure to show its metadata."
+  (interactive)
+  (let ((proc (inf-clojure-proc))
+        (last-sexp (buffer-substring-no-properties (save-excursion (backward-sexp) (point)) (point))))
+    (inf-clojure--send-string
+     proc
+     (format (inf-clojure-meta-form proc) last-sexp))))
 
 (defun inf-clojure-macroexpand (&optional macro-1)
   "Send a form to the inferior Clojure for macro expansion.


### PR DESCRIPTION
**Summary**

This commit addresses
https://github.com/clojure-emacs/inf-clojure/issues/57 (Add an interactive
command to display a var's metadata) by adding an interactive command `inf-clojure-meta` to show metadata of a form at point.

This command works with clojure, lumo and planck alike.

**Test Plan**

Manually tested the command through inf-clojure using clojure, lumo and planck. I put my cursor on a
form and ran it interactively, it displayed the metadata in the inf buffer.
Specifically I tested with `(with-meta [1 2 3] {:data "hello"})` which printed `{:data "hello"}` in the inf-clojure buffer.

-----------------
- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [X] You've updated the changelog (if adding/changing user-visible functionality)
- [NO] You've updated the readme (if adding/changing user-visible functionality)
  - It seems that we generally document higher level features and this does not warrant a change to the readme, let me know if you think that's necessary.