### PR TITLE
[Fix #154] Use setq-local for comint-input-sender

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -178,7 +178,7 @@ The following commands are available:
 
 \\{inf-clojure-minor-mode-map}"
   :lighter "" :keymap inf-clojure-minor-mode-map
-  (setq comint-input-sender 'inf-clojure--send-string)
+  (setq-local comint-input-sender 'inf-clojure--send-string)
   (inf-clojure-eldoc-setup)
   (make-local-variable 'completion-at-point-functions)
   (add-to-list 'completion-at-point-functions


### PR DESCRIPTION
This seems to work for me. I have not seen any problems with inf-clojure, and I have been using it daily on two different systems. I believe it resolved the issue when using Racket/Geiser, but I have not tested it extensively.
