### PR TITLE
Fix typo in inf-clojure--joker-repl-form

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -282,7 +282,7 @@ often connecting to a remote REPL process."
 
 (defcustom inf-clojure--joker-repl-form
   "(find-ns 'joker.repl)"
-  "Form to invoke in order to verify that we launched a Planck REPL."
+  "Form to invoke in order to verify that we launched a Joker REPL."
   :type 'string
   :safe #'stringp
   :package-version '(inf-clojure . "2.2.0"))


### PR DESCRIPTION
Fixes a doc typo introduced in https://github.com/clojure-emacs/inf-clojure/pull/160

-----------------

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
