### PR TITLE
Fix for eldoc-mode for ClojureCLR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master (unreleased)
 
+# [#164](https://github.com/clojure-emacs/inf-clojure/pull/164): Fix for eldoc-mode on ClojureCLR
 * [#160](https://github.com/clojure-emacs/inf-clojure/pull/160): Support [Joker](https://joker-lang.org/).
 * [#135](https://github.com/clojure-emacs/inf-clojure/pull/135): Improve command sanitation code.
 

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -900,7 +900,7 @@ If you are using REPL types, it will pickup the most appropriate
       (clojure.core/meta
        (clojure.core/resolve
         (clojure.core/read-string \"%s\"))))
-     (catch Throwable t nil))"
+     (catch #?(:clj Throwable :cljr Exception) e nil))"
   "Form to query inferior Clojure for a function's arglists."
   :type 'string
   :safe #'stringp


### PR DESCRIPTION
When using the REPL, whenever you'd type the function name, because
`Throwable` is JVM specific, `eldoc-mode` would try to look up the
function and when it wouldn't find it, it would bomb out with the
complaint that `Throwable` wasn't defined. Which is to be expected since
it's not running on JVM.

Looking at the documentation
https://docs.oracle.com/javase/10/docs/api/java/lang/Throwable.html

> The Throwable class is the superclass of all errors and exceptions in the Java language.

And in C#, Exception
https://docs.microsoft.com/en-us/dotnet/api/system.exception?redirectedfrom=MSDN&view=netframework-4.8

> This class is the base class for all exceptions.


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
