### PR TITLE
[Fix #152]  Sanitize should only remove whitespace at the end of a command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,6 @@ default: &default-steps
   steps:
     - checkout
     - run: apt-get update && apt-get install make
-    - run: make elpa
     - run: make test
 
 # Enumerated list of Emacs versions

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,19 @@
+.PHONY: clean version test
+
+all: build
+
+clean:
+	rm -rf .cask
+
+.cask:
+	cask install
+	cask update
+
 version:
 	emacs --version
 
-test : version
-	cask exec buttercup -L .
+build: version .cask
+	cask build
 
-elpa:
-	cask install
-	cask update
+test: version .cask
+	cask exec buttercup -L .

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -319,27 +319,15 @@ It requires a REPL PROC for inspecting the correct type."
     inf-clojure-repl-type))
 
 (defun inf-clojure--whole-comment-line-p (string)
-  "Return true iff STRING is a whole line semicolon comment."
+  "Return non-nil iff STRING is a whole line semicolon comment."
   (string-match-p "^\s*;" string))
-
-(defun inf-clojure--make-single-line (string)
-  "Convert a multi-line STRING in a single-line STRING.
-It also reduces redundant whitespace for readability and removes
-comments."
-  (let* ((lines (seq-filter (lambda (s) (not (inf-clojure--whole-comment-line-p s)))
-                            (split-string string "[\r\n]" t))))
-    (mapconcat (lambda (s)
-                 (if (not (string-match-p ";" s))
-                     (replace-regexp-in-string "\s+" " " s)
-                   (concat s "\n")))
-               lines " ")))
 
 (defun inf-clojure--sanitize-command (command)
   "Sanitize COMMAND for sending it to a process.
 An example of things that this function does is to add a final
 newline at the end of the form.  Return an empty string if the
 sanitized command is empty."
-  (let ((sanitized (inf-clojure--make-single-line command)))
+  (let ((sanitized (string-trim-right command)))
     (if (string-blank-p sanitized)
         ""
       (concat sanitized "\n"))))

--- a/test/inf-clojure-tests.el
+++ b/test/inf-clojure-tests.el
@@ -111,24 +111,6 @@
          (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
                  :to-equal "deref")))))
 
-(describe "inf-clojure--make-single-line"
-  (it "replaces newlines with whitespace"
-      (expect (inf-clojure--make-single-line "(do\n(println \"hello world\")\n)") :to-equal "(do (println \"hello world\") )"))
-
-  (it "does not leave whitespace at the end"
-      (expect (inf-clojure--make-single-line "(do\n(println \"hello world\")\n)\n\n") :to-equal "(do (println \"hello world\") )"))
-
-  (it "returns empty string when the line is only newlines"
-      (expect (inf-clojure--make-single-line "\n\n\n\n") :to-equal ""))
-
-  (it "removes comments when on their own line"
-      (expect (inf-clojure--make-single-line "(do\n(println \"hello world\")\n    ;; remove me\n)") :to-equal "(do (println \"hello world\") )"))
-
-  (it "preserves newlines of inline comments"
-      (expect (inf-clojure--make-single-line "(do\n(println \"hello world\") ;; don't remove this\n)") :to-equal "(do (println \"hello world\") ;; don't remove this\n )"))
-
-  )
-
 (describe "inf-clojure--sanitize-command"
   (it "sanitizes the command correctly"
      (expect (inf-clojure--sanitize-command "(doc println)") :to-equal "(doc println)\n"))
@@ -137,6 +119,9 @@
      (expect (inf-clojure--sanitize-command "(doc println)\n\n\n\n") :to-equal "(doc println)\n"))
 
   (it "returns empty string when the command is empty"
-     (expect (inf-clojure--sanitize-command "   ") :to-equal "")))
+      (expect (inf-clojure--sanitize-command "   ") :to-equal ""))
+
+  (it "only removes whitespace at the end of the command - fix 152"
+     (expect (inf-clojure--sanitize-command "1   5") :to-equal "1   5\n")))
 
 ;;; inf-clojure-tests.el ends here


### PR DESCRIPTION
This patch makes sure that we trim at the right of the sanitized command only.

I am open to get rid completely of the sanitation but I do not have the time
now for trying on all the platform.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [X] The commits are consistent with our [contribution guidelines][1]
- [X] The new code is not generating bytecode or `M-x checkdoc` warnings
- [] You've updated the changelog (if adding/changing user-visible functionality)
- [] You've updated the readme (if adding/changing user-visible functionality)