### PR TITLE
[Fix #178] Ensure there is a directory for comint (thanks mcphailm)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * [#174](https://github.com/clojure-emacs/inf-clojure/pull/174): Set REPL type from startup form or prompt at startup, introduce `inf-clojure-custom-repl-type` defcustom.
 * [#174](https://github.com/clojure-emacs/inf-clojure/pull/174): Invoke `inf-clojure` with a prefix argument to prevent using `inf-clojure-custom-startup` and `inf-clojure-custom-repl-type.
 
+### Bugs fixed
+
+* [#178](https://github.com/clojure-emacs/inf-clojure/issues/178): Ensure a valid directory is used when starting process.
+
 ## 2.2.0 (2020-04-15)
 
 ### New features

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -667,7 +667,7 @@ process buffer for a list of commands.)"
                                           'confirm-after-completion))))
   (if (not (comint-check-proc "*inf-clojure*"))
       ;; run the new process in the project's root when in a project folder
-      (let ((default-directory (clojure-project-dir))
+      (let ((default-directory (or (clojure-project-dir) default-directory))
             (cmdlist (if (consp cmd)
                          (list cmd)
                        (split-string cmd)))


### PR DESCRIPTION
If there was no containing directory with a project file the
default-directory would be nil. This leads to problems in starting up
inf-clojure and also annoyingly seems to set an error in a timer:

> Error running timer 'auto-revert-buffers (wrong-type-argument string nil)


Fixes https://github.com/clojure-emacs/inf-clojure/issues/178
