### PR TITLE
Ensure comint-truncate-buffer call is from the repl buffer

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -598,8 +598,11 @@ to continue it."
 (defun inf-clojure-clear-repl-buffer ()
   "Clear the REPL buffer."
   (interactive)
-  (let ((comint-buffer-maximum-size 0))
-    (comint-truncate-buffer)))
+  (with-current-buffer (if (derived-mode-p 'inf-clojure-mode)
+                           (current-buffer)
+                         inf-clojure-buffer)
+    (let ((comint-buffer-maximum-size 0))
+      (comint-truncate-buffer))))
 
 (defun inf-clojure-switch-to-repl (eob-p)
   "Switch to the inferior Clojure process buffer.


### PR DESCRIPTION
When clearing comint buffer ensure we are actually in the repl buffer