### PR TITLE
Handle newlines between forms for `inf-clojure-eval-buffer`

### DIFF
--- a/test/inf-clojure-tests.el
+++ b/test/inf-clojure-tests.el
@@ -119,6 +119,35 @@
   (it "only removes whitespace at the end of the command - fix 152"
     (expect (inf-clojure--sanitize-command "1   5") :to-equal "1   5\n")))
 
+(describe "inf-clojure--forms-without-newlines"
+  (it "removes newlines between toplevel forms"
+    (expect (inf-clojure--forms-without-newlines
+             "(def foo 3)\n\n\n(def bar 4)")
+            :to-equal "(def foo 3)\n(def bar 4)"))
+  (it "doesn't remove newlines inside forms or strings"
+    (expect (inf-clojure--forms-without-newlines
+             "
+
+(defn foo []
+
+  :foo)
+
+
+(def thing \"this
+
+is a string\")
+
+(defn bar [])")
+            ;; note no leading newline, newlines inside defn remain,
+            ;; newlines inside string remain
+            :to-equal "(defn foo []
+
+  :foo)
+(def thing \"this
+
+is a string\")
+(defn bar [])")))
+
 
 (describe "inf-clojure--update-feature"
   (it "updates new forms correctly"

--- a/test/inf-clojure-tests.el
+++ b/test/inf-clojure-tests.el
@@ -48,76 +48,77 @@
     (expect (inf-clojure--kw-to-symbol "::keyword") :to-equal "keyword")
     (expect (inf-clojure--kw-to-symbol nil) :to-equal nil)))
 
-(describe "completion bounds at point" ()
+(describe "completion bounds at point"
   (it "computes bounds for plain-text"
-      (ict-with-assess-buffers
-       ((a (insert "plain-text")))
-       (with-current-buffer a
-         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
-                 :to-equal "plain-text"))))
+    (ict-with-assess-buffers
+     ((a (insert "plain-text")))
+     (with-current-buffer a
+       (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+               :to-equal "plain-text"))))
 
   (it "computes bounds for @deref"
-      (ict-with-assess-buffers
-       ((a (insert "@deref")))
-       (with-current-buffer a
-         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
-                 :to-equal "deref"))))
+    (ict-with-assess-buffers
+     ((a (insert "@deref")))
+     (with-current-buffer a
+       (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+               :to-equal "deref"))))
 
   (it "computes bounds for ^:keyword"
-      (ict-with-assess-buffers
-       ((a (insert "^:keyword")))
-       (with-current-buffer a
-         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
-                 :to-equal ":keyword"))))
+    (ict-with-assess-buffers
+     ((a (insert "^:keyword")))
+     (with-current-buffer a
+       (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+               :to-equal ":keyword"))))
 
   (it "computes bounds for ::keyword"
-      (ict-with-assess-buffers
-       ((a (insert "::keyword")))
-       (with-current-buffer a
-         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
-                 :to-equal "::keyword"))))
+    (ict-with-assess-buffers
+     ((a (insert "::keyword")))
+     (with-current-buffer a
+       (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+               :to-equal "::keyword"))))
 
   (it "computes bounds for [^:keyword (combined break chars and keyword)"
-      (ict-with-assess-buffers
-       ((a (insert "[^:keyword")))
-       (with-current-buffer a
-         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
-                 :to-equal ":keyword"))))
+    (ict-with-assess-buffers
+     ((a (insert "[^:keyword")))
+     (with-current-buffer a
+       (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+               :to-equal ":keyword"))))
 
   (it "computes no bounds for point directly after a break expression"
-      (ict-with-assess-buffers
-       ((a (insert "@")))
-       (with-current-buffer a
-         (expect
-          (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
-          :not :to-be nil))))
+    (ict-with-assess-buffers
+     ((a (insert "@")))
+     (with-current-buffer a
+       (expect
+        (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+        :not :to-be nil))))
 
   (it "computes bounds for [symbol"
-      (ict-with-assess-buffers
-       ((a (insert "[symbol")))
-       (with-current-buffer a
-         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
-                 :to-equal "symbol"))))
+    (ict-with-assess-buffers
+     ((a (insert "[symbol")))
+     (with-current-buffer a
+       (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+               :to-equal "symbol"))))
 
   (it "computes bounds for (@deref (multiple break chars)"
-      (ict-with-assess-buffers
-       ((a (insert "(@deref")))
-       (with-current-buffer a
-         (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
-                 :to-equal "deref")))))
+    (ict-with-assess-buffers
+     ((a (insert "(@deref")))
+     (with-current-buffer a
+       (expect (ict-bounds-string (inf-clojure-completion-bounds-of-expr-at-point))
+               :to-equal "deref")))))
 
 (describe "inf-clojure--sanitize-command"
   (it "sanitizes the command correctly"
-     (expect (inf-clojure--sanitize-command "(doc println)") :to-equal "(doc println)\n"))
+    (expect (inf-clojure--sanitize-command "(doc println)") :to-equal "(doc println)\n"))
 
   (it "trims newline at the right of a command"
-     (expect (inf-clojure--sanitize-command "(doc println)\n\n\n\n") :to-equal "(doc println)\n"))
+    (expect (inf-clojure--sanitize-command "(doc println)\n\n\n\n") :to-equal "(doc println)\n"))
 
   (it "returns empty string when the command is empty"
-      (expect (inf-clojure--sanitize-command "   ") :to-equal ""))
+    (expect (inf-clojure--sanitize-command "   ") :to-equal ""))
 
   (it "only removes whitespace at the end of the command - fix 152"
-     (expect (inf-clojure--sanitize-command "1   5") :to-equal "1   5\n")))
+    (expect (inf-clojure--sanitize-command "1   5") :to-equal "1   5\n")))
+
 
 (describe "inf-clojure--update-feature"
   (it "updates new forms correctly"


### PR DESCRIPTION
This sends the contents of the buffer. However, newlines cause the
prompt to be returned. You can see this with even a regular clojure
repl:
```bash
❯❯❯ clojure
Clojure 1.10.2
user=>
user=>
user=>
```
(note using `clj` has rlwrap which hides a bit of this so make sure to
use `clojure`).

But what we can do is make sure to transform
```clojure
(defn foo [] ...)

(defn bar [] ...)
```

into

```clojure
(defn foo [] ...)
(defn bar [] ...)
```

So that the newlines don't trigger more repl prompts. Real world usage below:

Before:
```clojure
parse=>
nil
parse=> parse=> nil
parse=> parse=> #'parse/data
parse=> parse=> #'parse/parse-where
parse=> parse=> #'parse/keywords
parse=> parse=> #'parse/tokenize
parse=>
parse=> #'parse/parse
parse=> parse=> #'parse/translate-where
parse=> parse=> nil
parse=> parse=> #'parse/query
parse=> parse=> #'parse/query-test
parse=> parse=> #'parse/bonus-points-test
parse=>
```

After:
```clojure
user=>
nil
parse=> nil
parse=> #'parse/data
parse=> #'parse/parse-where
parse=> #'parse/keywords
parse=>
parse=> #'parse/parse
parse=> #'parse/translate-where
parse=> nil
parse=> #'parse/query
parse=> #'parse/query-test
parse=> #'parse/bonus-points-test
parse=>
```
