### PR TITLE
Font lock on repl inserts

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -752,7 +752,8 @@ Indent FORM.  FORM is expected to have been trimmed."
         (insert (format "%s" form))
         (let ((end (point)))
           (goto-char beginning)
-          (indent-sexp end)))
+          (indent-sexp end)
+          (font-lock-ensure beginning end)))
       (comint-send-input t t))))
 
 (defun inf-clojure-insert-defun ()


### PR DESCRIPTION
Just a simple call to font lock the repl when inserting

<img width="863" alt="image" src="https://user-images.githubusercontent.com/6377293/111084875-9b6cb480-84e2-11eb-92b2-6736dac9532c.png">
