### PR TITLE
Fix byte compile warnings

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -507,7 +507,7 @@ Clojure to load that file."
 ;; :reload-all implies :reload and also forces loading of all libs that the
 ;; identified libs directly or indirectly load via require or use
 
-(defun inf-clojure-reload-form (proc)
+(defun inf-clojure-reload-form (_proc)
   "Return the form to query the Inf-Clojure PROC for reloading a namespace.
 If you are using REPL types, it will pickup the most appropriate
 `inf-clojure-reload-form` variant."
@@ -525,7 +525,7 @@ Clojure to load that file."
   :safe #'stringp
   :package-version '(inf-clojure . "2.2.0"))
 
-(defun inf-clojure-reload-all-form (proc)
+(defun inf-clojure-reload-all-form (_proc)
   "Return the form to query the Inf-Clojure PROC for :reload-all of a namespace.
 If you are using REPL types, it will pickup the most appropriate
 `inf-clojure-reload-all-form` variant."

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -450,7 +450,8 @@ number (e.g. (\"localhost\" . 5555))."
    "Form to be used to start `inf-clojure'.
 Can be a cons pair of (host . port) where host is a string and
 port is an integer, or a string to startup an interpreter like
-\"planck\".")
+\"planck\"."
+   :type '(choice (cons string integer) (const nil)))
 
 (defcustom inf-clojure-custom-repl-type
   nil


### PR DESCRIPTION
Fix following warnings

- referencing free variables
- unused variables
- unspecified `:type` attribute

```
In inf-clojure-get-feature:
inf-clojure.el:168:27: Warning: reference to free variable
    ‘inf-clojure-repl-type’

In inf-clojure-proc:
inf-clojure.el:198:29: Warning: reference to free variable
    ‘inf-clojure-buffer’

In inf-clojure-set-repl:
inf-clojure.el:228:13: Warning: assignment to free variable
    ‘inf-clojure-buffer’

In inf-clojure--modeline-info:
inf-clojure.el:281:21: Warning: reference to free variable
    ‘inf-clojure-buffer’
inf-clojure.el:412:12: Warning: defcustom for ‘inf-clojure-custom-startup’
    fails to specify type
inf-clojure.el:412:12: Warning: defcustom for ‘inf-clojure-custom-startup’
    fails to specify type

In inf-clojure-reload-form:
inf-clojure.el:474:33: Warning: Unused lexical argument `proc'

In inf-clojure-reload-all-form:
inf-clojure.el:492:37: Warning: Unused lexical argument `proc'

In inf-clojure-completions:
inf-clojure.el:1266:18: Warning: reference to free variable
    ‘inf-clojure-completions-fn’
```

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
