### PR TITLE
Adds an option to disable eldoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New features
 
-* [#187](https://github.com/clojure-emacs/inf-clojure/pull/197): Defvar `inf-clojure-eldoc-enabledp` to disable eldoc interaction.
+* [#187](https://github.com/clojure-emacs/inf-clojure/pull/197): Defcustom `inf-clojure-enable-eldoc` to disable eldoc interaction.
 
 ## 3.1.0 (2021-07-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master (unreleased)
 
+### New features
+
+* [#187](https://github.com/clojure-emacs/inf-clojure/pull/197): Defvar `inf-clojure-eldoc-enabledp` to disable eldoc interaction.
+
 ## 3.1.0 (2021-07-23)
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ list of the function call you are currently editing in the echo area. It
 accomplishes this by evaluating forms to get the metadata for the vars under
 your cursor. One side effect of this is that it can mess with repl vars like
 `*1` and `*2`. You can disable inf-clojure's Eldoc functionality with `(setq
-inf-clojure-eldoc-enabledp nil)`.
+inf-clojure-enable-eldoc nil)`.
 
 
 ElDoc should be enabled by default in Emacs 26.1+. If it is not active by

--- a/README.md
+++ b/README.md
@@ -356,18 +356,20 @@ startup when using the `inf-clojure` command or is specified manually when using
 
 #### ElDoc
 
-**Note:** You can skip this section if you're using Emacs 26.1+, as `eldoc-mode`
-is enabled by default there.
-
 `eldoc-mode` is supported in Clojure source buffers and `*inferior-clojure*`
 buffers which are running a Clojure REPL.
 
-When ElDoc is enabled and there is an active REPL, it will show the
-argument list of the function call you are currently editing in the
-echo area.
+When ElDoc is enabled and there is an active REPL, it will show the argument
+list of the function call you are currently editing in the echo area. It
+accomplishes this by evaluating forms to get the metadata for the vars under
+your cursor. One side effect of this is that it can mess with repl vars like
+`*1` and `*2`. You can disable inf-clojure's Eldoc functionality with `(setq
+inf-clojure-eldoc-enabledp nil)`.
 
-You can activate ElDoc with `M-x eldoc-mode` or by adding the
-following to you Emacs config:
+
+ElDoc should be enabled by default in Emacs 26.1+. If it is not active by
+default, you can activate ElDoc with `M-x eldoc-mode` or by adding the following
+to you Emacs config:
 
 ```emacs-lisp
 (add-hook 'clojure-mode-hook #'eldoc-mode)

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -384,7 +384,7 @@ mode line entirely."
   :type 'sexp
   :risky t)
 
-(defvar inf-clojure-eldoc-enabledp t
+(defcustom inf-clojure-eldoc-enabledp t
   "Var that allows disabling `eldoc-mode` in `inf-clojure`.
 
 Set to `nil` to disable eldoc.  Eldoc can be quite useful by

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -1403,10 +1403,18 @@ Return the number of nested sexp the point was over or after."
           (setq inf-clojure-eldoc-last-symbol (cons thing arglists))
           arglists)))))
 
+(defvar inf-clojure-eldoc-enabledp t
+  "Var that allows disabling `eldoc-mode` in `inf-clojure`.
+
+Set to `nil` to disable eldoc.  Eldoc can be quite useful by
+displaying funciton signatures in the modeline, but can also
+cause multiple prompts to appear and mess with `*1`, `*2`, etc.")
+
 (defun inf-clojure-eldoc ()
   "Backend function for eldoc to show argument list in the echo area."
   ;; todo: this never gets unset once connected and is a lie
-  (when (and (inf-clojure-connected-p)
+  (when (and inf-clojure-eldoc-enabledp
+             (inf-clojure-connected-p)
              ;; don't clobber an error message in the minibuffer
              (not (member last-command '(next-error previous-error))))
     (let* ((info (inf-clojure-eldoc-info-in-current-sexp))

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -1416,6 +1416,7 @@ Return the number of nested sexp the point was over or after."
   "Backend function for eldoc to show argument list in the echo area."
   ;; todo: this never gets unset once connected and is a lie
   (when (and (inf-clojure-connected-p)
+             inf-clojure-eldoc-enabledp
              ;; don't clobber an error message in the minibuffer
              (not (member last-command '(next-error previous-error))))
     (let* ((info (inf-clojure-eldoc-info-in-current-sexp))

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -384,6 +384,13 @@ mode line entirely."
   :type 'sexp
   :risky t)
 
+(defvar inf-clojure-eldoc-enabledp t
+  "Var that allows disabling `eldoc-mode` in `inf-clojure`.
+
+Set to `nil` to disable eldoc.  Eldoc can be quite useful by
+displaying funciton signatures in the modeline, but can also
+cause multiple prompts to appear and mess with `*1`, `*2`, etc.")
+
 ;;;###autoload
 (define-minor-mode inf-clojure-minor-mode
   "Minor mode for interacting with the inferior Clojure process buffer.
@@ -394,7 +401,8 @@ The following commands are available:
   :lighter inf-clojure-mode-line
   :keymap inf-clojure-minor-mode-map
   (setq-local comint-input-sender 'inf-clojure--send-string)
-  (inf-clojure-eldoc-setup)
+  (when inf-clojure-eldoc-enabledp
+    (inf-clojure-eldoc-setup))
   (make-local-variable 'completion-at-point-functions)
   (add-to-list 'completion-at-point-functions
                #'inf-clojure-completion-at-point))
@@ -631,7 +639,8 @@ to continue it."
   (setq mode-line-process '(":%s"))
   (clojure-mode-variables)
   (clojure-font-lock-setup)
-  (inf-clojure-eldoc-setup)
+  (when inf-clojure-eldoc-enabledp
+    (inf-clojure-eldoc-setup))
   (setq comint-get-old-input #'inf-clojure-get-old-input)
   (setq comint-input-filter #'inf-clojure-input-filter)
   (setq-local comint-prompt-read-only inf-clojure-prompt-read-only)
@@ -1403,18 +1412,10 @@ Return the number of nested sexp the point was over or after."
           (setq inf-clojure-eldoc-last-symbol (cons thing arglists))
           arglists)))))
 
-(defvar inf-clojure-eldoc-enabledp t
-  "Var that allows disabling `eldoc-mode` in `inf-clojure`.
-
-Set to `nil` to disable eldoc.  Eldoc can be quite useful by
-displaying funciton signatures in the modeline, but can also
-cause multiple prompts to appear and mess with `*1`, `*2`, etc.")
-
 (defun inf-clojure-eldoc ()
   "Backend function for eldoc to show argument list in the echo area."
   ;; todo: this never gets unset once connected and is a lie
-  (when (and inf-clojure-eldoc-enabledp
-             (inf-clojure-connected-p)
+  (when (and (inf-clojure-connected-p)
              ;; don't clobber an error message in the minibuffer
              (not (member last-command '(next-error previous-error))))
     (let* ((info (inf-clojure-eldoc-info-in-current-sexp))

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -384,7 +384,7 @@ mode line entirely."
   :type 'sexp
   :risky t)
 
-(defcustom inf-clojure-eldoc-enabledp t
+(defcustom inf-clojure-enable-eldoc t
   "Var that allows disabling `eldoc-mode` in `inf-clojure`.
 
 Set to `nil` to disable eldoc.  Eldoc can be quite useful by
@@ -401,7 +401,7 @@ The following commands are available:
   :lighter inf-clojure-mode-line
   :keymap inf-clojure-minor-mode-map
   (setq-local comint-input-sender 'inf-clojure--send-string)
-  (when inf-clojure-eldoc-enabledp
+  (when inf-clojure-enable-eldoc
     (inf-clojure-eldoc-setup))
   (make-local-variable 'completion-at-point-functions)
   (add-to-list 'completion-at-point-functions
@@ -639,7 +639,7 @@ to continue it."
   (setq mode-line-process '(":%s"))
   (clojure-mode-variables)
   (clojure-font-lock-setup)
-  (when inf-clojure-eldoc-enabledp
+  (when inf-clojure-enable-eldoc
     (inf-clojure-eldoc-setup))
   (setq comint-get-old-input #'inf-clojure-get-old-input)
   (setq comint-input-filter #'inf-clojure-input-filter)
@@ -1416,7 +1416,7 @@ Return the number of nested sexp the point was over or after."
   "Backend function for eldoc to show argument list in the echo area."
   ;; todo: this never gets unset once connected and is a lie
   (when (and (inf-clojure-connected-p)
-             inf-clojure-eldoc-enabledp
+             inf-clojure-enable-eldoc
              ;; don't clobber an error message in the minibuffer
              (not (member last-command '(next-error previous-error))))
     (let* ((info (inf-clojure-eldoc-info-in-current-sexp))

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -388,7 +388,7 @@ mode line entirely."
   "Var that allows disabling `eldoc-mode` in `inf-clojure`.
 
 Set to `nil` to disable eldoc.  Eldoc can be quite useful by
-displaying funciton signatures in the modeline, but can also
+displaying function signatures in the modeline, but can also
 cause multiple prompts to appear and mess with `*1`, `*2`, etc.")
 
 ;;;###autoload


### PR DESCRIPTION
Eldoc is quite nice and puts the function signatures in the
minibuffer. But it does this at a cost. Since inf-clojure only uses a
single connection (currently at least) the commands interrupt the
values of `*1`, `*2`, etc. Further, this can lead to multiple prompts
appearing in the repl buffer.

```clojure
user=> user=> (map inc (range 4))
(1 2 3 4)
user=> user=> *1
nil
user=>
```

`user` appears multiple times, and then `*1` has been bound to the
result of getting arglists

```clojure
user=> (+ 1 1)
2
user=> *1
([f] [f coll] [f c1 c2] [f c1 c2 c3] [f c1 c2 c3 & colls])
```

The multiple prompts is quite annoying when inserting forms into the
repl.

Note that `*1` is oftentimes `nil` because eldoc just runs `(try (:arglists (meta _whatever-your-cursor-is-on)) (catch nil))` whenever your cursor stays on something for too long. This is also not throwing away too much functionality since you can easily get the docstring in the repl by `C-c C-v` (`inf-clojure-show-var-documentation`)