### PR TITLE
Improve cmd string splitting, fixes #185

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -775,7 +775,7 @@ process buffer for a list of commands.)"
       (let ((default-directory (or project-dir default-directory))
             (cmdlist (if (consp cmd)
                          (list cmd)
-                       (split-string cmd)))
+                       (split-string-and-unquote cmd)))
             (repl-type (or (unless prefix-arg
                              inf-clojure-custom-repl-type)
                            (car (rassoc cmd inf-clojure-startup-forms))


### PR DESCRIPTION
The following now works: (inf-clojure "clojure -Sdeps \"{:deps {insn/insn {:mvn/version \\\"0.5.4\\\"}}}\"")
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
