### PR TITLE
Added function for switching back from an inf-clojure buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#168](https://github.com/clojure-emacs/inf-clojure/pull/197): Helper function `inf-clojure-switch-to-recent-buffer` to select the last buffer an inf-clojure process buffer was swapped to from.
 * [#187](https://github.com/clojure-emacs/inf-clojure/pull/197): Defcustom `inf-clojure-enable-eldoc` to disable eldoc interaction.
 
 ## 3.1.0 (2021-07-23)

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -816,7 +816,9 @@ process buffer for a list of commands.)"
   "Connect to a running socket REPL server via `inf-clojure'.
 HOST is the host the process is running on, PORT is where it's listening."
   (interactive "shost: \nnport: ")
-  (inf-clojure (cons host port)))
+  (progn
+    (setq inf-clojure--recent-buffer (current-buffer))
+    (inf-clojure (cons host port))))
 
 (defun inf-clojure--forms-without-newlines (str)
   "Remove newlines between toplevel forms.

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -702,7 +702,7 @@ to continue it."
          ;; that already has the window in it.
          (or pop-up-frames
              (get-buffer-window to-buffer t))))
-    (pop-to-buffer to-buffer)))
+    (pop-to-buffer to-buffer '(display-buffer-reuse-window . ()))))
 
 (defun inf-clojure-switch-to-repl (eob-p)
   "Switch to the inferior Clojure process buffer.


### PR DESCRIPTION
This addresses https://github.com/clojure-emacs/inf-clojure/issues/168 by creating `inf-clojure--recent-buffer` to keep track of the buffer the repl was switched to from.  It's set on both `inf-clojure` and `inf-clojure-switch-to-repl` which hopefully means it can never be unintentionally `nil`.  If `inf-clojure-switch-to-recent-buffer` is called and `inf-clojure--recent-buffer` IS `nil` the message `"inf-clojure: No recent buffer known."` is sent.

This only tracks the most recent buffer among all repls, it will not manage multiple references in the case of multiple repls.

I'm by no means an elisp expert, if there are improvements to be made I'm happy to hear them.  I'm gonna try to take on more changes, I love having an opportunity to contribute!

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
