### PR TITLE
Addressed prompt duplication by printing nothing when response is prompt by itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New features
 
+* [#201](https://github.com/clojure-emacs/inf-clojure/pull/201): Reduce prompt duplication.
 * [#187](https://github.com/clojure-emacs/inf-clojure/pull/197): Defcustom `inf-clojure-enable-eldoc` to disable eldoc interaction.
 
 ## 3.1.0 (2021-07-23)

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -684,12 +684,19 @@ to continue it."
   (let* ((last-line (car (last (split-string str "\n"))))
          (response-was-one-line (string= last-line str))
          (last-line-was-prompt (string-match inf-clojure-prompt last-line))
-         (filtered (if (and inf-clojure--previous-response-ended-with-prompt
-                            response-was-one-line
-                            last-line-was-prompt)
-                       ;; Prevent prompts from stacking in the same line.
-                       ""
-                     (inf-clojure-chomp (concat "\n" str)))))
+         (filtered (cond
+                    ;; Just a prompt.
+                    ((and inf-clojure--previous-response-ended-with-prompt
+                          response-was-one-line
+                          last-line-was-prompt)
+                     "")
+                    ;; Not just a prompt, not the beginning of a response, don't insert unnecessary lines.
+                    ;; This should be a continuation of a previous response.
+                    ((not inf-clojure--previous-response-ended-with-prompt)
+                     str)
+                    ;; This should be the beginning of a response.
+                    (t
+                     (concat "\n" str)))))
     (set 'inf-clojure--previous-response-ended-with-prompt last-line-was-prompt)
     filtered))
 

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -676,8 +676,6 @@ to continue it."
   "Remove subprompts from STRING."
   (replace-regexp-in-string inf-clojure-subprompt "" string))
 
-(defvar inf-clojure--previous-response-ended-with-prompt nil)
-
 (defun inf-clojure-preoutput-filter (str)
   "Preprocess the output STR from interactive commands."
   (inf-clojure--log-string str "<-RES----")
@@ -801,6 +799,7 @@ process buffer for a list of commands.)"
           (inf-clojure-mode)
           (set-syntax-table clojure-mode-syntax-table)
           (setq-local inf-clojure-repl-type repl-type)
+          (defvar-local inf-clojure--previous-response-ended-with-prompt nil)
           (hack-dir-local-variables-non-file-buffer))))
     ;; update the default comint buffer and switch to it
     (setq inf-clojure-buffer (get-buffer repl-buffer-name))


### PR DESCRIPTION
This change is intended to fix the problem of the prompt being printed in line with a previously printed prompt.  The issue manifests as a prompt that looks like `user=> user=>` and has the potential to print many more times than that.

It happens when an evaluation takes long enough for shorter requests to finish before the long one does.  This has commonly come up for me when running tests or invoking `load-file` while completions are configured to execute through the inf-clojure process.

This pr addresses the fix in 2 steps.

First, ALL non-blanked responses are prepended by newline, as opposed to only those fulfilling `(string-prefix-p "inf-clojure-" (symbol-name (or this-command last-command)))`.  At a minimum this makes sure multiple results can't show up on the same line, which also helps to prevent the prompt from getting misaligned.  I wasn't entirely certain what was going on with the `string-prefix-p`, in my testing it didn't appear to affect inf-clojure- evals, though they were somehow being filtered anyway.

Second, `inf-clojure--previous-response-ended-with-prompt` keeps track of whether the previous response ended with a prompt.  If it was, and if we get only a prompt in the next request, we can replace the response with an empty string, which will leave the point at the previous prompt and appear to the user as if there was no response.

I don't consider this ready to merge, I really want to use it for a while and make sure it's enough.  So far it appears to be working pretty well.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
