### PR TITLE
Ensure repl scrolls on insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## master (unreleased)
 * [#202](https://github.com/clojure-emacs/inf-clojure/issues/202): Add ClojureCLR support.
+* [#204](https://github.com/clojure-emacs/inf-clojure/issues/204): Scroll repl buffer on insert commands
+
 
 ## 3.2.1 (2022-07-22)
 

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -920,6 +920,8 @@ Prefix argument AND-GO means switch to the Clojure buffer afterwards."
   "Insert FORM into process and evaluate.
 Indent FORM.  FORM is expected to have been trimmed."
   (let ((clojure-process (inf-clojure-proc)))
+    ;; ensure the repl buffer scrolls. See similar fix in CIDER:
+    ;; https://github.com/clojure-emacs/cider/pull/2590
     (with-selected-window (or (get-buffer-window inf-clojure-buffer)
                               (selected-window))
       (with-current-buffer (process-buffer clojure-process)

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -920,16 +920,19 @@ Prefix argument AND-GO means switch to the Clojure buffer afterwards."
   "Insert FORM into process and evaluate.
 Indent FORM.  FORM is expected to have been trimmed."
   (let ((clojure-process (inf-clojure-proc)))
-    (with-current-buffer (process-buffer clojure-process)
-      (comint-goto-process-mark)
-      (let ((beginning (point)))
-        (insert (format "%s" form))
-        (let ((end (point)))
-          (goto-char beginning)
-          (indent-sexp end)
-          ;; font-lock the inserted code
-          (font-lock-ensure beginning end)))
-      (comint-send-input t t))))
+    (with-selected-window (or (get-buffer-window inf-clojure-buffer)
+                              (selected-window))
+      (with-current-buffer (process-buffer clojure-process)
+        (comint-goto-process-mark)
+        (let ((beginning (point)))
+          (insert form)
+          (let ((end (point)))
+            (goto-char beginning)
+            (indent-sexp end)
+            ;; font-lock the inserted code
+            (font-lock-ensure beginning end)
+            (goto-char end)))
+        (comint-send-input t t)))))
 
 (defun inf-clojure-insert-defun ()
   "Send current defun to process."


### PR DESCRIPTION
When inserting forms into the repl, the buffer doesn't always scroll to
show the new input and result. This has been fixed in CIDER in a similar
way so bringing the same trick here.

https://github.com/clojure-emacs/cider/pull/2590