### PR TITLE
Use comint-mode-map as parent map instead

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -339,7 +339,8 @@ Either \"no process\" or \"buffer-name(repl-type)\""
     "no process"))
 
 (defvar inf-clojure-mode-map
-  (let ((map (copy-keymap comint-mode-map)))
+  (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map comint-mode-map)
     (define-key map (kbd "C-x C-e") #'inf-clojure-eval-last-sexp)
     (define-key map (kbd "C-c C-l") #'inf-clojure-load-file)
     (define-key map (kbd "C-c C-a") #'inf-clojure-show-arglists)


### PR DESCRIPTION
Whilst playing with inf-clojure-mode-map, some previous binds are overriden, because copy-keymap is used instead of set-parent-map. This will help for that.

<!---
-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):
-->
- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [ ] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
