### PR TITLE
Display message after setting repl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master (unreleased)
 * [#202](https://github.com/clojure-emacs/inf-clojure/issues/202): Add ClojureCLR support.
 * [#204](https://github.com/clojure-emacs/inf-clojure/issues/204): Scroll repl buffer on insert commands
+* [#208](https://github.com/clojure-emacs/inf-clojure/pull/208) Display message after setting repl.
 
 
 ## 3.2.1 (2022-07-22)

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -281,14 +281,17 @@ ALWAYS-ASK).  Otherwise get a list of all active inf-clojure
 REPLS and offer a choice.  It's recommended to rename REPL
 buffers after they are created with `rename-buffer'."
   (interactive "P")
-  (if (and (not always-ask)
-           (inf-clojure-repl-p))
-      (setq inf-clojure-buffer (current-buffer))
-    (let ((repl-buffers (inf-clojure-repls)))
-     (if (> (length repl-buffers) 0)
-         (when-let ((repl-buffer (completing-read "Select default REPL: " repl-buffers nil t)))
-           (setq inf-clojure-buffer (get-buffer repl-buffer)))
-       (user-error "No buffers have an inf-clojure process")))))
+  (let ((new-repl-buffer
+         (if (and (not always-ask)
+                  (inf-clojure-repl-p))
+             (setq inf-clojure-buffer (current-buffer))
+           (let ((repl-buffers (inf-clojure-repls)))
+             (if (> (length repl-buffers) 0)
+                 (when-let ((repl-buffer (completing-read "Select default REPL: " repl-buffers nil t)))
+                   (setq inf-clojure-buffer (get-buffer repl-buffer)))
+               (user-error "No buffers have an inf-clojure process"))))))
+    (when new-repl-buffer
+      (message "Current inf-clojure REPL set to %s" new-repl-buffer))))
 
 (defvar inf-clojure--repl-type-lock nil
   "Global lock for protecting against proc filter race conditions.

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -281,17 +281,17 @@ ALWAYS-ASK).  Otherwise get a list of all active inf-clojure
 REPLS and offer a choice.  It's recommended to rename REPL
 buffers after they are created with `rename-buffer'."
   (interactive "P")
-  (let ((new-repl-buffer
-         (if (and (not always-ask)
-                  (inf-clojure-repl-p))
-             (setq inf-clojure-buffer (current-buffer))
-           (let ((repl-buffers (inf-clojure-repls)))
-             (if (> (length repl-buffers) 0)
-                 (when-let ((repl-buffer (completing-read "Select default REPL: " repl-buffers nil t)))
-                   (setq inf-clojure-buffer (get-buffer repl-buffer)))
-               (user-error "No buffers have an inf-clojure process"))))))
-    (when new-repl-buffer
-      (message "Current inf-clojure REPL set to %s" new-repl-buffer))))
+  (if (and (not always-ask)
+           (inf-clojure-repl-p))
+      (progn
+        (setq inf-clojure-buffer (current-buffer))
+        (message "Current inf-clojure REPL set to %s" inf-clojure-buffer))
+    (let ((repl-buffers (inf-clojure-repls)))
+      (if (> (length repl-buffers) 0)
+          (when-let ((repl-buffer (completing-read "Select default REPL: " repl-buffers nil t)))
+            (setq inf-clojure-buffer (get-buffer repl-buffer))
+            (message "Current inf-clojure REPL set to %s" inf-clojure-buffer))
+        (user-error "No buffers have an inf-clojure process")))))
 
 (defvar inf-clojure--repl-type-lock nil
   "Global lock for protecting against proc filter race conditions.


### PR DESCRIPTION
Displays a message after setting the repl.

When manually setting a repl with `inf-clojure-set-repl`, there is no visual indication that the repl has successfully been changed. This has confused me a few times in the past so I added a message.

This was [briefly discussed on slack](https://clojurians.slack.com/archives/C099W16KZ/p1672414905867309)


-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [ ] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
