### PR TITLE
Include user function to create a socket repl inside emacs/inf-clojure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#202](https://github.com/clojure-emacs/inf-clojure/issues/202): Add ClojureCLR support.
 * [#204](https://github.com/clojure-emacs/inf-clojure/issues/204): Scroll repl buffer on insert commands
 * [#208](https://github.com/clojure-emacs/inf-clojure/pull/208) Display message after setting repl.
+* [#210](https://github.com/clojure-emacs/inf-clojure/pull/210) Include `inf-clojure-socket-repl` to create a socket REPL and connect to it from inside Emacs. 
 
 
 ## 3.2.1 (2022-07-22)

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ common startup forms. You can select one of these or type in your own
 custom startup. This will start a REPL process for the current project
 and you can start interacting with it.
 
+If you want to use a socket REPL server, use `M-x inf-clojure-socket-repl`
+which will start a socket server and connect to it for you.
+
 If you've already started a socket REPL server, use `M-x inf-clojure-connect`
 and enter its host and port numbers.
 


### PR DESCRIPTION
This PR addresses the issue #209 I raised yesterday, introducing the `inf-clojure-socket` function to create and connect to a socket REPL from within Emacs.

Additionally:
- There are two buffer variables `inf-clojure-buffer` as before and also `inf-clojure-cljs-buffer`. This is a somewhat dirty solution that builds on the current implementation, this is useful as it's common for projects to use clj & cljs together.
- `inf-clojure--get-buffer` returns the right global buffer variable `inf-clojure-buffer` or `inf-clojure-cljs-buffer` depending on whether your are currently in a clojurescript buffer/file.
- I've deliberately tried not to make all functions work with `inf-clojure-cljs-buffer` to avoid this PR ballooning, I've only done the neccessary changes to allow clojurescript-mode buffers to eval code seperately. Functions like `inf-clojure-set-repl`, `inf-clojure-clear-repl-buffer` and `inf-clojure-connected-p` have been left as `inf-clojure-buffer` only functions for example.
- When closing a REPL buffer, the socket buffer is also closed (well by default the user is asked if they want to kill them one by one)

I've tested this using:
- `M-x inf-clojure-socket`
- `M-: (inf-clojure-socket :port 5555 :repl-type "clojure")`
- `M-: (inf-clojure-socket :repl-type "cljs")`
- Running C-x C-e, eval-last-sexp in clojure and cljs buffers when there is no running REPL
- Running C-x C-e, eval-last-sexp in clojure and cljs buffers when there other REPL (cljs vs. clojure) is running only
- Running C-x C-e, eval-last-sexp in clojure and cljs buffers when both cljs and clojure REPLs are running.
- Switching between a file and it's corresponding REPL with C-c C-z for both cljs and clojure. (incidentally this is really useful vs. my old workflow of C-x b'ing between the buffers!)

As well as setting `inf-clojure-cli-args` to nil and "-Mdev" to make sure this was being included when the socket server was started.

Should we include keybinds for launching clj, cljs and clj&cljs socket REPLs like cider jack-in?

Unsure about naming conventions but I've made my best guesses, so any recommendations for changes please let me know!