### PR TITLE
Cleanup socket repl startup.

### DIFF
--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -610,8 +610,8 @@ This should usually be a combination of `inf-clojure-prompt' and
 
 (defcustom inf-clojure-auto-mode t
   "Automatically enable inf-clojure-minor-mode.
-All buffers will automatically be in `inf-clojure-minor-mode'
-unless set to nil."
+All buffers in `clojure-mode' will automatically be in
+`inf-clojure-minor-mode' unless set to nil."
   :type 'boolean
   :safe #'booleanp
   :package-version '(inf-clojure . "3.1.0"))

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -609,7 +609,9 @@ This should usually be a combination of `inf-clojure-prompt' and
   :package-version '(inf-clojure . "2.0.0"))
 
 (defcustom inf-clojure-auto-mode t
-  "When non-nil, automatically enable inf-clojure-minor-mode for all Clojure buffers."
+  "Automatically enable inf-clojure-minor-mode.
+All buffers will automatically be in `inf-clojure-minor-mode'
+unless set to nil.."
   :type 'boolean
   :safe #'booleanp
   :package-version '(inf-clojure . "3.1.0"))
@@ -895,7 +897,7 @@ OUTPUT is the latest data received from the process"
 	  (when inf-clojure-socket-callback
 	    (funcall inf-clojure-socket-callback)))))))
 
-(defun inf-clojure-socket-repl-sentinel (process event)
+(defun inf-clojure-socket-repl-sentinel (process _event)
   "Ensures socket REPL are cleaned up when the REPL buffer is closed.
 
 PROCESS is the process object that is connected to a socket REPL.

--- a/inf-clojure.el
+++ b/inf-clojure.el
@@ -611,7 +611,7 @@ This should usually be a combination of `inf-clojure-prompt' and
 (defcustom inf-clojure-auto-mode t
   "Automatically enable inf-clojure-minor-mode.
 All buffers will automatically be in `inf-clojure-minor-mode'
-unless set to nil.."
+unless set to nil."
   :type 'boolean
   :safe #'booleanp
   :package-version '(inf-clojure . "3.1.0"))


### PR DESCRIPTION
Fixes: https://github.com/clojure-emacs/inf-clojure/issues/211

**How to use:**

To use one of the defaults defined in
`inf-clojure-socket-repl-startup-forms`, just `m-x inf-clojure-socket-repl` and choose your startup.

To add your own custom startup

```emacs-lisp
(setq inf-clojure-custom-startup
      "clojure -J-Dclojure.server.repl=\"{:port %d :accept clojure.core.server/repl}\" -A:grepl")
```

This will prompt you for a repl type so it's useful to also include

```emacs-lisp
(setq inf-clojure-custom-repl-type 'clojure)
```

Or set these in a .dir-locals.el file for each project with

```emacs-lisp
;;; Directory Local Variables
;;; For more information see (info "(emacs) Directory Variables")

((nil . ((inf-clojure-custom-startup . "clojure -J-Dclojure.server.repl=\"{:port %d :accept clojure.core.server/repl}\" -A:grepl")
         (inf-clojure-custom-repl-type . clojure))))
```

**things i changed**
- added `(defvar inf-clojure-custom-repl-name nil)`. This was originally used but never defined so socket startup and inf-connect would fail. This also was not honored and now controls the repl buffer name.
- removed `inf-clojure-socket-repl-type`. This was also used and never defined so it also caused startup to fail. But we already have a notion of `inf-clojure-custom-repl-type` so we can just reuse that. There's nothing special about it being the socket repl type for connect.
- simplified the buffer startup mechanism. Lots of `let` bindings
- added `inf-clojure--suppress-connect-message-p`. Ostensibly private, others can use it. But two things are sending messages: how we start the clojure process, and that we connected to the clojure process. I think how we start the clojure process is the far more important one as it includes port information, aliases, etc.

cc: @jakub-stastny @mikepjb 