### PR TITLE
Add `clojure-ts-mode` support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
 ## master (unreleased)
+
 * Improve support for multiple forms in the same line by replacing beginning-of-defun fn.
 * [#202](https://github.com/clojure-emacs/inf-clojure/issues/202): Add ClojureCLR support.
 * [#204](https://github.com/clojure-emacs/inf-clojure/issues/204): Scroll repl buffer on insert commands
 * [#208](https://github.com/clojure-emacs/inf-clojure/pull/208) Display message after setting repl.
-* [#210](https://github.com/clojure-emacs/inf-clojure/pull/210) Include `inf-clojure-socket-repl` to create a socket REPL and connect to it from inside Emacs. 
-
+* [#210](https://github.com/clojure-emacs/inf-clojure/pull/210) Include `inf-clojure-socket-repl` to create a socket REPL and connect to it from inside Emacs.
+- [#217](https://github.com/clojure-emacs/inf-clojure/pull/217): Add `clojure-ts-mode` support.
 
 ## 3.2.1 (2022-07-22)
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ You can also add the following to your Emacs config to enable
 
 ```emacs-lisp
 (add-hook 'clojure-mode-hook #'inf-clojure-minor-mode)
+
+;; or if you're a `clojure-ts-mode' user:
+
+(add-hook 'clojure-ts-mode-hook #'inf-clojure-minor-mode)
 ```
 
 **Warning:** Don't enable `inf-clojure-minor-mode` and `cider-mode` at the same time. They
@@ -215,6 +219,18 @@ If you want to update a specific form there is a function
 
 ```emacs-lisp
 (inf-clojure-update-feature 'clojure 'completion "(incomplete.core/completions \"%s\")")
+```
+
+### `clojure-ts-mode` support
+
+`inf-clojure` will try to use `clojure-ts-mode` by default if it's
+available with fallback to `clojure-mode`.
+
+If you want to use `inf-clojure` with `clojure-mode` exclusively, you
+can set it to:
+
+```emacs-lisp
+(setopt inf-clojure-source-modes '(clojure-mode))
 ```
 
 #### Caveats


### PR DESCRIPTION
#215 has no activity for more than 2 years, so I decided to create a new one.

Initially I planned to add a new `inf-clojure-preferred-major-mode` variable, but then I discovered `inf-clojure-source-modes` and I think it's a good idea to use it for this feature.

`clojure-ts-mode` is used in the most places if selected as a preferred major mode, except a few places where required functions are missing. I left comments in the code.

-----------------

Before submitting the PR make sure the following things have been done (and denote this
by checking the relevant checkboxes):

- [x] The commits are consistent with our [contribution guidelines][1]
- [x] The new code is not generating bytecode or `M-x checkdoc` warnings
- [x] You've updated the changelog (if adding/changing user-visible functionality)
- [x] You've updated the readme (if adding/changing user-visible functionality)

Thanks!

[1]: https://github.com/clojure-emacs/inf-clojure/blob/master/.github/CONTRIBUTING.md
